### PR TITLE
[SCMO-8382] mock-server upgraded to 5.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
     <!-- test -->
     <scala-test.version>3.1.0-RC1</scala-test.version>
+    <mock-server.version>5.1.1</mock-server.version>
 
     <!-- plugins -->
     <scala-maven-plugin.version>4.2.0</scala-maven-plugin.version>
@@ -331,7 +332,7 @@
       <dependency>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver-netty</artifactId>
-        <version>3.11</version>
+        <version>${mock-server.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>

--- a/pyron-core/pom.xml
+++ b/pyron-core/pom.xml
@@ -17,10 +17,6 @@
       <artifactId>vertx-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.circe</groupId>
-      <artifactId>circe-core_2.12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.cloudentity.tools.vertx</groupId>
       <artifactId>vertx-bus</artifactId>
     </dependency>


### PR DESCRIPTION
Trying to resolve timeouts in tests (caused by `org.mockserver.integration.ClientAndServer - Failed to send stop request to MockServer Response was not received after 120000 milliseconds`)