### PR TITLE
added methodCtx entity provider in authn plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - MultiOidcClient support for oidc-server configs in map format
 - request body streaming, buffering, dropping
 - request body max size limit
+- methodCtx entity provider in authn plugin
 
 ### Changed
 - RoutingCtx moved to flow Properties

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/authn/EntityProvider.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/authn/EntityProvider.scala
@@ -9,3 +9,11 @@ trait EntityProvider {
   @VertxEndpoint
   def getEntity(tracingCtx: TracingContext, ctx: AuthnCtx): Future[AuthnCtx]
 }
+
+/**
+ * Generic entity provider putting all data returned by authn method into authn context.
+ */
+class MethodCtxEntityProvider extends EntityProvider {
+  override def getEntity(tracingCtx: TracingContext, ctx: AuthnCtx): Future[AuthnCtx] =
+    Future.succeededFuture(ctx)
+}


### PR DESCRIPTION
This PR extends `authn` plugin with an entity provider available for all authentication methods. It puts all data returned by a method provider into authentication context. 