### PR TITLE
SCMO-8523 SCMO-8521 jackson-databind + libthrift vulnerability mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@
 ### Removed
 - CorrelationCtx
 
+### Security
+- [CVE-2019-20330](https://nvd.nist.gov/vuln/detail/CVE-2019-20330) - Fixed by upgrading jackson-databind 2.9.10.1 -> 2.9.10.3
+- [CVE-2020-8840](https://nvd.nist.gov/vuln/detail/CVE-2020-8840) - Fixed by upgrading jackson-databind 2.9.10.1 -> 2.9.10.3
+- [CVE-2018-20200](https://nvd.nist.gov/vuln/detail/CVE-2018-20200) - Fixed by underlying vertx-tools libthrift 0.12.0 -> 0.13.0
+- [CVE-2019-0205](https://nvd.nist.gov/vuln/detail/CVE-2019-0205) - Fixed by underlying vertx-tools libthrift 0.12.0 -> 0.13.0
+- [CVE-2019-0210](https://nvd.nist.gov/vuln/detail/CVE-2019-0210) - Fixed by underlying vertx-tools libthrift 0.12.0 -> 0.13.0
+
 ## [1.0.0] - 2019-11-27
 ### Added
 - Initial version

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <vertx.version>3.8.0</vertx.version>
     <vertx-tools.version>1.1.0-SNAPSHOT</vertx-tools.version>
     <circe.version>0.11.1</circe.version>
-    <jackson-databind.version>2.9.10.1</jackson-databind.version>
+    <jackson-databind.version>2.9.10.3</jackson-databind.version>
     <embedded-consul.version>1.0.0</embedded-consul.version>
     <slf4j.version>1.8.0-beta4</slf4j.version>
     <bouncycastle.bcprov.version>1.62</bouncycastle.bcprov.version>

--- a/sample-scala-plugins/pom.xml
+++ b/sample-scala-plugins/pom.xml
@@ -15,8 +15,8 @@
 
   <properties>
     <scala.version>2.12.9</scala.version>
-    <pyron.version>1.0.0-SNAPSHOT</pyron.version>
-    <vertx-tools.version>1.0.0-SNAPSHOT</vertx-tools.version>
+    <pyron.version>1.1.0-SNAPSHOT</pyron.version>
+    <vertx-tools.version>1.1.0-SNAPSHOT</vertx-tools.version>
     <scala-maven-plugin.version>4.2.0</scala-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
- Upgraded jackson-databind 2.9.10.1 -> 2.9.10.3

- Fixed pyron version in sample-scala-plugins to remove vulnerabilities

- Updating CHANGELOG to reflect solved libthrift vulnerabilities from underlying vertx-tools upgrade