### PR TITLE
rules 'default' attribute is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - vertx-tools upgraded to 1.1.0
 - plugin logger names contain bus address prefix
 - 'authn' and 'cors' plugin modules adjusted for use in api-groups
+- rules 'default' attribute is optional
 
 ### Fixed
 - multipart Content-Type handling

--- a/pyron-engine/src/main/scala/com/cloudentity/pyron/rule/RulesConfReader.scala
+++ b/pyron-engine/src/main/scala/com/cloudentity/pyron/rule/RulesConfReader.scala
@@ -16,7 +16,7 @@ object RulesConfReader {
   import Codecs._
 
   // list of ServiceRulesConf matches rules.json schema
-  case class ServiceRulesConf(default: RuleRawConf, request: Option[ServiceFlowsConf], response: Option[ServiceFlowsConf], endpoints: List[EndpointConf])
+  case class ServiceRulesConf(default: Option[RuleRawConf], request: Option[ServiceFlowsConf], response: Option[ServiceFlowsConf], endpoints: List[EndpointConf])
   case class ServiceConf(rule: RuleRawConf, request: Option[ServiceFlowsConf], response: Option[ServiceFlowsConf])
 
   case class ServiceFlowsConf(preFlow: Option[ServiceFlowConf], postFlow: Option[ServiceFlowConf])
@@ -49,6 +49,8 @@ object RulesConfReader {
     call: Option[CallOpts],
     ext: Option[ExtRuleConf]
   )
+
+  val emptyRuleRawConf = RuleRawConf(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
 
   sealed trait ReadRulesError
     case class RuleDecodingError(ex: Throwable) extends ReadRulesError
@@ -124,7 +126,7 @@ object RulesConfReader {
         (serviceConf, i)  <- serviceConfs.zipWithIndex
         (endpointConf, j) <- serviceConf.endpoints.zipWithIndex
       } yield {
-        composeRuleConf(addresses, ServiceConf(serviceConf.default, serviceConf.request, serviceConf.response), endpointConf)
+        composeRuleConf(addresses, ServiceConf(serviceConf.default.getOrElse(emptyRuleRawConf), serviceConf.request, serviceConf.response), endpointConf)
           .leftMap(errorMsgs => errorMsgs.map(errorMsg => s"Service $i, endpoint $j,${endpointConf.rule.endpointName.map(n => s" '$n'").getOrElse("")} $errorMsg"))
       }
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RulesConfReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RulesConfReaderSpec.scala
@@ -13,7 +13,7 @@ import scalaz.{Failure, Success}
 
 @RunWith(classOf[JUnitRunner])
 class RulesConfReaderSpec extends WordSpec with MustMatchers {
-  val emptyRuleConf = RuleRawConf(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None ,None, None)
+  val emptyRuleConf = RulesConfReader.emptyRuleRawConf
   val emptyConf = ServiceConf(emptyRuleConf, None, None)
   val fullRuleConfWoPlugins = RuleRawConf(Some("endpointName"), Some(TargetHost("targetHost")), Some(80), None, None, None, Some(PathPattern("pathPattern")), None, None, None, None, Some(PathPrefix("pathPrefix")), Some(HttpMethod.GET), Some(true), None, None, None, None, None, None, None)
   val otherFullRuleConfWoPlugins = RuleRawConf(Some("endpointName2"), Some(TargetHost("targetHost2")), Some(802), None, None, None, Some(PathPattern("pathPattern2")), None, None, None, None, Some(PathPrefix("pathPrefix2")), Some(HttpMethod.POST), Some(false), None, None, None, None, None, None, None)
@@ -117,7 +117,7 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
 
   "RulesReader.composeRuleConfs" should {
     "should aggregate all missing fields" in {
-      val conf = ServiceRulesConf(emptyRuleConf, None, None, List(endpointConf(emptyRuleConf)))
+      val conf = ServiceRulesConf(Some(emptyRuleConf), None, None, List(endpointConf(emptyRuleConf)))
       RulesConfReader.composeRuleConfs(List(conf, conf), Map()) match {
         case Success(_) => fail
         case Failure(fs) =>


### PR DESCRIPTION
Thanks to this change we don't need to use empty `default` attribute, e.g. instead of:
```{
  "rules": [
    {
    	"default": {
    	},
      "endpoints": [
        {
          "targetHost": "localhost",
          "targetPort": 7760,
          "method": "GET",
          "pathPattern": "/user"
        }
      ]
    }
  ]
}```

we can have:
```{
  "rules": [
    {
      "endpoints": [
        {
          "targetHost": "localhost",
          "targetPort": 7760,
          "method": "GET",
          "pathPattern": "/user"
        }
      ]
    }
  ]
}```