### PR TITLE
Feature/dynamic scopes support AUT-2919

### DIFF
--- a/pyron-core/src/main/scala/com/cloudentity/pyron/domain/flow/flow.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/domain/flow/flow.scala
@@ -92,7 +92,7 @@ object TargetService {
     DiscoverableService(serviceName)
 
   private def readStaticService(req: HttpServerRequest): StaticService = {
-    lazy val ssl = req.isSSL
+    val ssl = req.isSSL
     if (Option(req.host()).isDefined) {
       Option(req.host()).get.split(':').toList match {
         case h :: Nil => StaticService(TargetHost(h), 80, ssl)

--- a/pyron-core/src/main/scala/com/cloudentity/pyron/openapi/OpenApiUtils.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/openapi/OpenApiUtils.scala
@@ -55,8 +55,9 @@ trait OpenApiConverterUtils {
   }
 
   def pathMatches(testPath: String, regexPath: String): Boolean = {
-    val normalizedTargetServicePath = testPath.replaceAll("\\{|\\}", "")
-    PathMatcher.makeMatch(normalizedTargetServicePath, PathMatching.build(PathPrefix(""), PathPattern(regexPath))).isDefined
+    val normalizedTargetServicePath = testPath.replaceAll("[{}]", "")
+    val pathMatching = PathMatching.build(PathPrefix(""), PathPattern(regexPath))
+    PathMatcher.makeMatch(normalizedTargetServicePath, pathMatching).isDefined
   }
 
   def toSwaggerMethod(method: io.vertx.core.http.HttpMethod): io.swagger.models.HttpMethod = {

--- a/pyron-core/src/main/scala/com/cloudentity/pyron/rule/PathMatcher.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/rule/PathMatcher.scala
@@ -1,12 +1,11 @@
 package com.cloudentity.pyron.rule
 
-import com.cloudentity.pyron.domain._
 import com.cloudentity.pyron.domain.flow.{PathMatching, PathParams}
 
 object PathMatcher {
   def makeMatch(path: String, matcher: PathMatching): Option[PathParams] =
     matcher.regex.findFirstMatchIn(path).flatMap[PathParams] { mtch =>
-      if (mtch.groupCount == matcher.paramNames.size)
+      if (mtch.groupCount == matcher.paramNames.size) {
         Some(
           PathParams(
             matcher.paramNames.map { name =>
@@ -14,6 +13,6 @@ object PathMatcher {
             }.toMap
           )
         )
-      else None
+      } else None
     }
 }

--- a/pyron-core/src/main/scala/com/cloudentity/pyron/rule/PathMatcher.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/rule/PathMatcher.scala
@@ -3,16 +3,8 @@ package com.cloudentity.pyron.rule
 import com.cloudentity.pyron.domain.flow.{PathMatching, PathParams}
 
 object PathMatcher {
-  def makeMatch(path: String, matcher: PathMatching): Option[PathParams] =
-    matcher.regex.findFirstMatchIn(path).flatMap[PathParams] { mtch =>
-      if (mtch.groupCount == matcher.paramNames.size) {
-        Some(
-          PathParams(
-            matcher.paramNames.map { name =>
-              name.value -> mtch.group(name.value)
-            }.toMap
-          )
-        )
-      } else None
-    }
+  def makeMatch(path: String, matcher: PathMatching): Option[PathParams] = for {
+    found <- matcher.regex.findFirstMatchIn(path) if found.groupCount == matcher.paramNames.size
+    paramNamesAndValues = matcher.paramNames.map(name => name.value -> found.group(name.value))
+  } yield PathParams(paramNamesAndValues.toMap)
 }

--- a/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/QueryParamsSpec.scala
+++ b/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/QueryParamsSpec.scala
@@ -3,7 +3,7 @@ package com.cloudentity.pyron.domain.http
 import scala.util.Success
 import org.junit.runner.RunWith
 import org.scalatest.{MustMatchers, WordSpec}
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class QueryParamsSpec extends WordSpec with MustMatchers {

--- a/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/RelativeUriSpec.scala
+++ b/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/RelativeUriSpec.scala
@@ -2,7 +2,7 @@ package com.cloudentity.pyron.domain.http
 
 import com.cloudentity.pyron.domain.flow.PathParams
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupConflictsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupConflictsSpec.scala
@@ -2,7 +2,7 @@ package com.cloudentity.pyron.apigroup
 
 import com.cloudentity.pyron.domain.flow.{BasePath, DomainPattern, GroupMatchCriteria}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupReaderSpec.scala
@@ -4,7 +4,7 @@ import io.circe.Json
 import com.cloudentity.pyron.domain.flow.{BasePath, DomainPattern, GroupMatchCriteria, PluginName}
 import org.junit.runner.RunWith
 import org.scalatest.{MustMatchers, WordSpec}
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ApiGroupReaderSpec extends WordSpec with MustMatchers {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/client/SmartHttpConfsReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/client/SmartHttpConfsReaderSpec.scala
@@ -3,7 +3,7 @@ package com.cloudentity.pyron.client
 import com.cloudentity.pyron.domain.flow.{ServiceClientName, SmartHttpClientConf}
 import io.vertx.core.json.JsonObject
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 import scalaz.\/-
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiConverterVerticleTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiConverterVerticleTest.scala
@@ -1,16 +1,14 @@
 package com.cloudentity.pyron.openapi
 
 import com.cloudentity.pyron.VertxSpec
-import com.cloudentity.pyron.domain._
 import com.cloudentity.pyron.domain.flow.{GroupMatchCriteria, PathPattern, PathPrefix, RewriteMethod, RewritePath}
 import com.cloudentity.pyron.domain.openapi.{BasePath, ConverterConf, Host, OpenApiDefaultsConf, OpenApiRule}
-import com.cloudentity.pyron.domain.rule.{ExtRuleConf, OpenApiRuleConf}
 import com.cloudentity.pyron.util.{FutureUtils, OpenApiTestUtils}
 import com.cloudentity.tools.vertx.tracing.TracingContext
 import io.swagger.models.Scheme
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.collection.JavaConverters._

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/RequestPluginFunctionsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/RequestPluginFunctionsSpec.scala
@@ -1,6 +1,5 @@
 package com.cloudentity.pyron.plugin
 
-import com.cloudentity.pyron.api.Responses
 import com.cloudentity.pyron.test.TestRequestResponseCtx
 import com.cloudentity.pyron.domain.flow._
 import com.cloudentity.pyron.domain.http._
@@ -9,7 +8,7 @@ import com.cloudentity.tools.vertx.http.Headers
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/ResponsePluginFunctionsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/ResponsePluginFunctionsSpec.scala
@@ -8,7 +8,7 @@ import com.cloudentity.pyron.plugin.PluginFunctions.ResponsePlugin
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/PathMatchingSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/PathMatchingSpec.scala
@@ -2,7 +2,7 @@ package com.cloudentity.pyron.rule
 
 import com.cloudentity.pyron.domain.flow.{PathMatching, PathPattern}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RewritePathSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RewritePathSpec.scala
@@ -7,7 +7,7 @@ import com.cloudentity.tools.vertx.http.Headers
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
 import org.scalatest._
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RewritePathSpec extends FlatSpec {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RuleBuilderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RuleBuilderSpec.scala
@@ -6,15 +6,14 @@ import io.circe.generic.semiauto._
 import io.circe.{Decoder, Json}
 import com.cloudentity.pyron.VertxSpec
 import com.cloudentity.pyron.plugin.config._
-import com.cloudentity.pyron.domain._
-import com.cloudentity.pyron.domain.flow.{EndpointMatchCriteria, PathMatching, PathPrefix, PluginConf, ApiGroupPluginConf, PluginName, RequestCtx, ResponseCtx, StaticServiceRule, TargetHost}
+import com.cloudentity.pyron.domain.flow.{EndpointMatchCriteria, PathMatching, PathPrefix, ApiGroupPluginConf, PluginName, RequestCtx, ResponseCtx, StaticServiceRule, TargetHost}
 import com.cloudentity.pyron.domain.rule.{ExtRuleConf, RequestPluginsConf, ResponsePluginsConf, RuleConf, RuleConfWithPlugins}
 import com.cloudentity.pyron.plugin.verticle.{RequestPluginVerticle, ResponsePluginVerticle}
 import com.cloudentity.pyron.rule.RuleBuilder.InvalidPluginConf
 import com.cloudentity.tools.vertx.tracing.internals.JaegerTracing
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.concurrent.duration._

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RuleMatcherSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RuleMatcherSpec.scala
@@ -4,12 +4,12 @@ import com.cloudentity.pyron.domain.flow.{BasePath, EndpointMatchCriteria, PathM
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 @RunWith(classOf[JUnitRunner])
-class RuleMatcherSpec extends WordSpec with MustMatchers with GeneratorDrivenPropertyChecks {
+class RuleMatcherSpec extends WordSpec with MustMatchers with ScalaCheckDrivenPropertyChecks {
 
   import RuleMatcher._
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RulesConfReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RulesConfReaderSpec.scala
@@ -1,13 +1,12 @@
 package com.cloudentity.pyron.rule
 
 import io.circe.Json
-import com.cloudentity.pyron.domain._
 import com.cloudentity.pyron.domain.flow.{EndpointMatchCriteria, PathMatching, PathPattern, PathPrefix, PluginConf, ApiGroupPluginConf, PluginName, ServiceClientName, StaticServiceRule, TargetHost}
 import com.cloudentity.pyron.domain.rule.{ExtRuleConf, RequestPluginsConf, ResponsePluginsConf, RuleConf}
 import com.cloudentity.pyron.rule.RulesConfReader._
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 import scalaz.{Failure, Success}
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/util/JsonUtilSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/util/JsonUtilSpec.scala
@@ -4,11 +4,11 @@ import io.circe.Json
 import io.circe.testing.ArbitraryInstances
 import org.junit.runner.RunWith
 import org.scalatest.{MustMatchers, WordSpec}
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.junit.JUnitRunner
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 @RunWith(classOf[JUnitRunner])
-class JsonUtilSpec extends WordSpec with MustMatchers with ArbitraryInstances with GeneratorDrivenPropertyChecks {
+class JsonUtilSpec extends WordSpec with MustMatchers with ArbitraryInstances with ScalaCheckDrivenPropertyChecks {
   "JsonUtil.deepMerge" should {
     "preserve argument order" in forAll { (js: List[Json]) =>
       val fields = js.zipWithIndex.map {

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/authn/openapi/test/OpenApiTestUtils.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/authn/openapi/test/OpenApiTestUtils.scala
@@ -31,7 +31,7 @@ trait OpenApiTestUtils extends OpenApiConverterUtils {
   def multiPath(): Path = {
     val path = new Path()
     path.setGet(new Operation().operationId("getOperation").description("get desc").response(200, new Response().description("ok")))
-    path.setPost(new Operation().operationId("postOperation").description("get desc").response(200, new Response().description("ok")))
+    path.setPost(new Operation().operationId("postOperation").description("post desc").response(200, new Response().description("ok")))
     path.setPut(new Operation().operationId("putOperation").description("put desc").response(200, new Response().description("ok")))
     path
   }

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPlugin.scala
@@ -1,14 +1,14 @@
 package com.cloudentity.pyron.plugin.impl.transformer
 
-import io.circe.Decoder
-import com.cloudentity.pyron.plugin.config._
 import com.cloudentity.pyron.domain.flow.{PathParams, PluginName, RequestCtx}
 import com.cloudentity.pyron.domain.http.Headers
 import com.cloudentity.pyron.domain.openapi.OpenApiRule
 import com.cloudentity.pyron.openapi.OpenApiPluginUtils
+import com.cloudentity.pyron.plugin.config._
 import com.cloudentity.pyron.plugin.openapi._
 import com.cloudentity.pyron.plugin.util.value._
 import com.cloudentity.pyron.plugin.verticle.RequestPluginVerticle
+import io.circe.Decoder
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.{Parameter, PathParameter}
 import io.vertx.core.buffer.Buffer
@@ -16,8 +16,8 @@ import io.vertx.core.json.JsonObject
 import io.vertx.core.logging.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
-import scala.concurrent.Future
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 class TransformRequestPlugin extends RequestPluginVerticle[TransformerConf]
@@ -47,15 +47,13 @@ class TransformRequestPlugin extends RequestPluginVerticle[TransformerConf]
   }
 
   def resolveBodyOps(ctx: RequestCtx, bodyOps: BodyOps, jsonBodyOpt: Option[JsonObject]): ResolvedBodyOps =
-    ResolvedBodyOps(bodyOps.set.map(_.map { case (path, valueOrRef) => path -> ValueResolver.resolveJson(ctx, jsonBodyOpt, valueOrRef)}), bodyOps.drop)
+    ResolvedBodyOps(bodyOps.set.map(_.mapValues(ValueResolver.resolveJson(ctx, jsonBodyOpt, _))), bodyOps.drop)
 
   def resolvePathParamOps(ctx: RequestCtx, pathParamOps: PathParamOps, jsonBodyOpt: Option[JsonObject]): ResolvedPathParamOps =
-    ResolvedPathParamOps(pathParamOps.set.map(_.map { case (path, valueOrRef) => path -> ValueResolver.resolveString(ctx, jsonBodyOpt, valueOrRef)}))
+    ResolvedPathParamOps(pathParamOps.set.map(_.mapValues(ValueResolver.resolveString(ctx, jsonBodyOpt, _))))
 
   def resolveHeaderOps(ctx: RequestCtx, headerOps: HeaderOps, jsonBodyOpt: Option[JsonObject]): ResolvedHeaderOps =
-    ResolvedHeaderOps(headerOps.set.map(_.map {
-      case (path, valueOrRef) => path -> ValueResolver.resolveListOfStrings(ctx, jsonBodyOpt, valueOrRef)
-    }))
+    ResolvedHeaderOps(headerOps.set.map(_.mapValues(ValueResolver.resolveListOfStrings(ctx, jsonBodyOpt, _))))
 
   override def validate(conf: TransformerConf): ValidateResponse = ValidateOk
 

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPlugin.scala
@@ -12,9 +12,10 @@ import com.cloudentity.pyron.plugin.verticle.RequestPluginVerticle
 import io.swagger.models.Swagger
 import io.swagger.models.parameters.{Parameter, PathParameter}
 import io.vertx.core.buffer.Buffer
-import io.vertx.core.json.{JsonArray, JsonObject}
-import io.vertx.core.logging.LoggerFactory
+import io.vertx.core.json.JsonObject
+import io.vertx.core.logging.{Logger, LoggerFactory}
 
+import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -81,10 +82,11 @@ trait TransformJsonBody {
 
   // NOTE: this method mutates jsonBody
   def setJsonBody(set: Map[Path, Option[JsonValue]])(body: JsonObject): JsonObject = {
+    @tailrec
     def mutateBodyAttribute(body: JsonObject, bodyPath: List[String], resolvedValue: Option[JsonValue]): Unit =
       bodyPath match {
         case key :: Nil =>
-          body.put(key, resolvedValue.map(_.rawValue).getOrElse(null))
+          body.put(key, resolvedValue.map(_.rawValue).orNull)
 
         case key :: tail =>
           val leaf =
@@ -148,7 +150,7 @@ trait TransformHeaders {
 }
 
 object TransformRequestOpenApiConverter extends OpenApiPluginUtils {
-  val log = LoggerFactory.getLogger(this.getClass)
+  val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   def convertOpenApi(swagger: Swagger, rule: OpenApiRule, conf: TransformerConf): ConvertOpenApiResponse = {
     convertPathParams(conf.pathParams)(rule)(swagger)

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPlugin.scala
@@ -53,7 +53,9 @@ class TransformRequestPlugin extends RequestPluginVerticle[TransformerConf]
     ResolvedPathParamOps(pathParamOps.set.map(_.map { case (path, valueOrRef) => path -> ValueResolver.resolveString(ctx, jsonBodyOpt, valueOrRef)}))
 
   def resolveHeaderOps(ctx: RequestCtx, headerOps: HeaderOps, jsonBodyOpt: Option[JsonObject]): ResolvedHeaderOps =
-    ResolvedHeaderOps(headerOps.set.map(_.map { case (path, valueOrRef) => path -> ValueResolver.resolveListOfStrings(ctx, jsonBodyOpt, valueOrRef)}))
+    ResolvedHeaderOps(headerOps.set.map(_.map {
+      case (path, valueOrRef) => path -> ValueResolver.resolveListOfStrings(ctx, jsonBodyOpt, valueOrRef)
+    }))
 
   override def validate(conf: TransformerConf): ValidateResponse = ValidateOk
 

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/domain.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transformer/domain.scala
@@ -39,11 +39,11 @@ object TransformerConf {
   }
 
   private def jsonBodyReferenceExists(conf: TransformerConfRaw): Boolean =
-    List[Option[TransformOps]](conf.body, conf.pathParams, conf.headers).flatten.find {
-      case BodyOps(set, _)   => jsonBodyReferenceExists(set)
+    List[Option[TransformOps]](conf.body, conf.pathParams, conf.headers).flatten.exists {
+      case BodyOps(set, _) => jsonBodyReferenceExists(set)
       case PathParamOps(set) => jsonBodyReferenceExists(set)
-      case HeaderOps(set)    => jsonBodyReferenceExists(set)
-    }.isDefined
+      case HeaderOps(set) => jsonBodyReferenceExists(set)
+    }
 
   private def jsonBodyReferenceExists(refs: Option[Map[_, ValueOrRef]]): Boolean =
     refs.map(_.values).toList.flatten.exists(_.isInstanceOf[BodyRef])

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -136,7 +136,91 @@
         },
         {
           "method": "GET",
-          "pathPattern": "/dyn-header-from-body",
+          "pathPattern": "/dyn-header-can-find-multiple-params-and-reorder-them-in-output",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-Transaction": {
+                      "path": "$body.scp",
+                      "pattern": "transaction.{transactionId}/swift.{swiftId}",
+                      "output": "{swiftId}.{transactionId}"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-matches-regex-special-chars-as-literals",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-Payment": {
+                      "path": "$body.scp",
+                      "pattern": "(payment).is$ok[{id}]?",
+                      "output": "{id}"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-can-match-curly-braces-when-doubled",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-Client": {
+                      "path": "$body.scp",
+                      "pattern": "customer-{{{id}}}",
+                      "output": "{id}"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-can-use-fixed-mapping-for-non-array-values",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-DSKey": {
+                      "path": "$body.groups",
+                      "pattern": "admin",
+                      "output": "elevated"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-from-body-multiple-transformations",
           "requestPlugins": [
             {
               "name": "transform-request",

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -151,12 +151,12 @@
                     },
                     "DSKey": {
                       "path": "$body.scp",
-                      "pattern": "env.{num}",
+                      "pattern": "env.({num})",
                       "output": "{num}"
                     },
                     "X-SCP-Payment": {
                       "path": "$body.scp",
-                      "pattern": "payment_{id}",
+                      "pattern": "payment.[{id}]",
                       "output": "{id}"
                     },
                     "X-SCP-Transfer": {

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -133,6 +133,34 @@
               }
             }
           ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-from-body",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "DSKey": {
+                      "findAt": "scp",
+                      "prefix": "env."
+                    },
+                    "X-SCP-Payment": {
+                      "findAt": "scp",
+                      "prefix": "payment."
+                    },
+                    "X-SCP-Transfer": {
+                      "findAt": "scp",
+                      "prefix": "transfer."
+                    }
+                  }
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -146,15 +146,18 @@
                   "set": {
                     "DSKey": {
                       "path": "$body.scp",
-                      "pattern": "env."
+                      "pattern": "env.{num}",
+                      "output": "{num}"
                     },
                     "X-SCP-Payment": {
                       "path": "$body.scp",
-                      "pattern": "payment."
+                      "pattern": "payment_{id}",
+                      "output": "{id}"
                     },
                     "X-SCP-Transfer": {
                       "path": "$body.scp",
-                      "pattern": "transfer."
+                      "pattern": "transfer.{id}",
+                      "output": "{id}"
                     }
                   }
                 }

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -136,7 +136,7 @@
         },
         {
           "method": "GET",
-          "pathPattern": "/dyn-header-can-find-multiple-params-and-reorder-them-in-output",
+          "pathPattern": "/dyn-header-can-find-multiple-params-in-pattern-and-reorder-them-in-input",
           "requestPlugins": [
             {
               "name": "transform-request",
@@ -157,7 +157,59 @@
         },
         {
           "method": "GET",
-          "pathPattern": "/dyn-header-matches-regex-special-chars-as-literals",
+          "pathPattern": "/dyn-header-requires-pattern-matching-on-entire-value",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-Transaction": {
+                      "path": "$body.scp",
+                      "pattern": "transaction.{id}",
+                      "output": "{id}"
+                    },
+                    "X-Env": {
+                      "path": "$body.scp",
+                      "pattern": "env.{id}.suffix",
+                      "output": "{id}"
+                    },
+                    "X-Payment": {
+                      "path": "$body.scp",
+                      "pattern": "payment.{id}",
+                      "output": "{id}"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-will-get-first-value-for-take-all-pattern",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-Value": {
+                      "path": "$body.scp",
+                      "pattern": "{wholeThing}",
+                      "output": "{wholeThing}"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/dyn-header-can-match-regex-special-chars-literally",
           "requestPlugins": [
             {
               "name": "transform-request",
@@ -178,7 +230,7 @@
         },
         {
           "method": "GET",
-          "pathPattern": "/dyn-header-can-match-curly-braces-when-doubled",
+          "pathPattern": "/dyn-header-can-match-literal-curly-braces",
           "requestPlugins": [
             {
               "name": "transform-request",
@@ -241,7 +293,7 @@
         },
         {
           "method": "GET",
-          "pathPattern": "/dyn-header-from-body-multiple-transformations",
+          "pathPattern": "/dyn-header-with-multiple-transformations",
           "requestPlugins": [
             {
               "name": "transform-request",

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -149,6 +149,11 @@
                       "pattern": "admin",
                       "output": "elevated"
                     },
+                    "X-Client": {
+                      "path": "$body.scp",
+                      "pattern": "customer-{{{id}}}_swift_{swift}",
+                      "output": "{swift}.{id}"
+                    },
                     "DSKey": {
                       "path": "$body.scp",
                       "pattern": "env.({num})",

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -220,6 +220,27 @@
         },
         {
           "method": "GET",
+          "pathPattern": "/dyn-header-can-use-dyn-mapping-for-non-array-values",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {},
+                "headers": {
+                  "set": {
+                    "X-Env": {
+                      "path": "$body.env",
+                      "pattern": "env.{id}",
+                      "output": "{id}"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
           "pathPattern": "/dyn-header-from-body-multiple-transformations",
           "requestPlugins": [
             {

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -145,16 +145,16 @@
                 "headers": {
                   "set": {
                     "DSKey": {
-                      "findAt": "scp",
-                      "prefix": "env."
+                      "path": "$body.scp",
+                      "pattern": "env."
                     },
                     "X-SCP-Payment": {
-                      "findAt": "scp",
-                      "prefix": "payment."
+                      "path": "$body.scp",
+                      "pattern": "payment."
                     },
                     "X-SCP-Transfer": {
-                      "findAt": "scp",
-                      "prefix": "transfer."
+                      "path": "$body.scp",
+                      "pattern": "transfer."
                     }
                   }
                 }

--- a/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transformer/rules.json
@@ -144,6 +144,11 @@
                 "body": {},
                 "headers": {
                   "set": {
+                    "X-Scope": {
+                      "path": "$body.groups",
+                      "pattern": "admin",
+                      "output": "elevated"
+                    },
                     "DSKey": {
                       "path": "$body.scp",
                       "pattern": "env.{num}",

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/AuthnPluginSpec.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/AuthnPluginSpec.scala
@@ -13,7 +13,7 @@ import io.circe.{Json, JsonObject}
 import io.vertx.core.{Future, Vertx}
 import io.vertx.core.buffer.Buffer
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.concurrent.Await

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/openapi/AuthnPluginOpenApiConverterOauthTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/openapi/AuthnPluginOpenApiConverterOauthTest.scala
@@ -23,12 +23,12 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
     properties = None
   )
 
-  val oauthConf = OpenApiOauthUrlsConf(
+  val oauthConf: OpenApiOauthUrlsConf = OpenApiOauthUrlsConf(
     authorizationUrl = OauthUrl("localhost", "/oauth/authorize", 80, ssl = false),
     tokenUrl = OauthUrl("localhost", "/oauth/token", 80, ssl = false)
   )
 
-  val pluginConf = AuthnApiOpenApiConf(
+  val pluginConf: AuthnApiOpenApiConf = AuthnApiOpenApiConf(
     Some(oauthConf), Map("authorizationCodeOAuth" -> Oauth2SecurityDefinitionConf(List(ImplicitFlow)))
   )
 
@@ -36,15 +36,13 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
 
     "append oauth to security definitions" in {
       val resp = convertWithSingleGetEndpoint(baseEndpointConf, pluginConf)
-      resp securityDefinitionsAssert { _.contains("oauth2_implicit") should be(true) }
+      resp securityDefinitionsAssert { _.contains("oauth2_implicit") shouldBe true }
     }
 
     "set proper flows in oauth security definitions" in {
       val resp = convertWithSingleGetEndpoint(baseEndpointConf, pluginConf)
       inside(resp.getSecurityDefinitions.get("oauth2_implicit")) {
-        case Some(oauthDef: OAuth2Definition) => {
-          oauthDef.getFlow should be ("implicit")
-        }
+        case Some(oauthDef: OAuth2Definition) => oauthDef.getFlow shouldBe "implicit"
         case _ => fail("Expected Oauth2Definition object")
       }
     }
@@ -56,16 +54,16 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
           Map("authorizationCodeOAuth" -> Oauth2SecurityDefinitionConf(List(ImplicitFlow, AuthorizationCodeFlow)))
         )
       )
-      resp securityDefinitionsAssert { _.contains("oauth2_implicit") should be(true) }
-      resp securityDefinitionsAssert { _.contains("oauth2_authorizationCode") should be(true) }
+      resp securityDefinitionsAssert { _.contains("oauth2_implicit") shouldBe true }
+      resp securityDefinitionsAssert { _.contains("oauth2_authorizationCode") shouldBe true }
 
       inside(resp.getSecurityDefinitions.get("oauth2_implicit")) {
-        case Some(oauthDef: OAuth2Definition) => oauthDef.getFlow should be ("implicit")
+        case Some(oauthDef: OAuth2Definition) => oauthDef.getFlow shouldBe "implicit"
         case _ => fail("Expected Oauth2Definition object")
       }
 
       inside(resp.getSecurityDefinitions.get("oauth2_authorizationCode")) {
-        case Some(oauthDef: OAuth2Definition) => oauthDef.getFlow should be ("accessCode")
+        case Some(oauthDef: OAuth2Definition) => oauthDef.getFlow shouldBe "accessCode"
         case _ => fail("Expected Oauth2Definition object")
       }
     }
@@ -81,9 +79,9 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
           )
         )
       )
-      resp securityDefinitionsAssert { _.contains("oauth2_implicit") should be(true) }
-      resp securityDefinitionsAssert { _.contains("oauth2_authorizationCode") should be(true) }
-      resp securityDefinitionsAssert { _.size should be(2) }
+      resp securityDefinitionsAssert { _.contains("oauth2_implicit") shouldBe true }
+      resp securityDefinitionsAssert { _.contains("oauth2_authorizationCode") shouldBe true }
+      resp securityDefinitionsAssert { _.size shouldBe 2 }
     }
 
     "add only one security definition when the same configuration is used on two endpoints" in {
@@ -99,7 +97,7 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
         pluginConf
       )
 
-      responses.last securityDefinitionsAssert { _.size should be (1) }
+      responses.last securityDefinitionsAssert { _.size shouldBe 1 }
     }
 
     "add multiple oauth definitions and security schemes when two endpoints with two different methods are used" in {
@@ -125,12 +123,12 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
         altPluginConf
       )
 
-      responses.last securityDefinitionsAssert { _.size should be (2) }
+      responses.last securityDefinitionsAssert { _.size shouldBe 2 }
     }
 
     "not add anything to security definitions when there are no configured methods, despite mappings being defined" in {
       val resp = convertWithSingleGetEndpoint(baseEndpointConf.copy(methods = List()), pluginConf)
-      resp securityDefinitionsAssert { _ should be(null) }
+      resp securityDefinitionsAssert { _ shouldBe null }
     }
 
     "add security scheme to endpoint definition" in {
@@ -140,8 +138,7 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
 
       val op = resp.getOperationByRule(params._2)
       val sec = op.getSecurity.asScala
-      sec should not be empty
-      sec.filter(_.containsKey("oauth2_implicit")) should not be empty
+      sec.exists(_.containsKey("oauth2_implicit")) shouldBe true
     }
 
     "add multiple security scheme to endpoint definition" in {
@@ -152,8 +149,8 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
       val resp = convertWithParams(params)
 
       val sec = resp.getOperationByRule(params._2).getSecurity.asScala
-      sec.filter(_.containsKey("oauth2_implicit")) should not be empty
-      sec.filter(_.containsKey("oauth2_authorizationCode")) should not be empty
+      sec.exists(_.containsKey("oauth2_implicit")) shouldBe true
+      sec.exists(_.containsKey("oauth2_authorizationCode")) shouldBe true
     }
 
     "set urls for implicit flow" in {
@@ -182,8 +179,8 @@ class AuthnPluginOpenApiConverterOauthTest extends WordSpec with Matchers with A
 
       inside(resp.getSecurityDefinitions.get(s"oauth2_${flow.name}")) {
         case Some(oauthDef: OAuth2Definition) =>
-          oauthDef.getAuthorizationUrl should be (authorizationUrl)
-          oauthDef.getTokenUrl should be (tokenUrl)
+          oauthDef.getAuthorizationUrl shouldBe authorizationUrl
+          oauthDef.getTokenUrl shouldBe tokenUrl
         case _ => fail("Expected Oauth2Definition object")
       }
     }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/openapi/AuthnPluginOpenApiConverterOauthTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/openapi/AuthnPluginOpenApiConverterOauthTest.scala
@@ -1,12 +1,12 @@
-package com.cloudentity.edge.plugin.impl.authn.openapi
+package com.cloudentity.pyron.plugin.impl.authn.openapi
 
 import com.cloudentity.pyron.plugin.impl.authn._
 import com.cloudentity.pyron.plugin.impl.authn.openapi.test.AuthnPluginOpenApiTestTools.SimpleTestEndpoint
-import com.cloudentity.pyron.plugin.impl.authn.openapi.test.{AuthnPluginOpenApiTestTools, OpenApiTestUtils}
+import com.cloudentity.pyron.plugin.impl.authn.openapi.test.AuthnPluginOpenApiTestTools
 import io.swagger.models.auth.OAuth2Definition
 import io.vertx.core.http.HttpMethod
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{Inside, Matchers, WordSpec}
 
 import scala.collection.JavaConverters._

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/bruteforce/BruteForceIdentifierReaderSpec.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/bruteforce/BruteForceIdentifierReaderSpec.scala
@@ -4,7 +4,7 @@ import com.cloudentity.pyron.test.TestRequestResponseCtx
 import io.circe.Json._
 import io.vertx.core.buffer.Buffer
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -35,7 +35,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getPath must be ("/fixed-path-param/fixed-param")
+      req.getPath mustBe "/fixed-path-param/fixed-param"
     }
   }
 
@@ -49,7 +49,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getPath must be ("/path-param-from-header/123")
+      req.getPath mustBe "/path-param-from-header/123"
     }
   }
 
@@ -63,7 +63,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getBodyAsString must be ("""{"attr":"value"}""")
+      req.getBodyAsString mustBe """{"attr":"value"}"""
     }
   }
 
@@ -77,7 +77,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getBodyAsString must be ("""{"attr":"value"}""")
+      req.getBodyAsString mustBe """{"attr":"value"}"""
     }
   }
 
@@ -91,7 +91,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getBodyAsRawBytes.length must be (0)
+      req.getBodyAsRawBytes.length mustBe 0
     }
   }
 
@@ -104,7 +104,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) must be (Some("value"))
+      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) mustBe Some("value")
     }
   }
 
@@ -117,7 +117,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) must be (Some("value"))
+      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) mustBe Some("value")
     }
   }
 
@@ -131,12 +131,43 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) must be (Some("value"))
+      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) mustBe Some("value")
     }
   }
 
+  @Test
+  def shouldSetDynHeaderFromBody(): Unit = {
+    val rand = scala.util.Random
+    val paymentId = rand.nextInt.abs
+    val transferId = rand.nextInt.abs
+    val envId = rand.nextInt.abs
+
+    given()
+      .body(s"""{"scp":["env.$envId","payment.$paymentId","transfer.$transferId"],"groups":"admin"}""")
+      .when()
+      .get("/dyn-header-from-body")
+      .`then`()
+      .statusCode(200)
+
+    assertTargetRequest { req =>
+      req.getHeaders.asScala.toList.find(_.getName.toString == "X-SCP-Payment")
+        .map(_.getValues.get(0)) mustBe Some(s"$paymentId")
+    }
+
+    assertTargetRequest { req =>
+      req.getHeaders.asScala.toList.find(_.getName.toString == "X-SCP-Transfer")
+        .map(_.getValues.get(0)) mustBe Some(s"$transferId")
+    }
+
+    assertTargetRequest { req =>
+      req.getHeaders.asScala.toList.find(_.getName.toString == "DSKey")
+        .map(_.getValues.get(0)) mustBe Some(s"$envId")
+    }
+
+  }
+
   def assertTargetRequest(f: HttpRequest => Unit): Unit = {
-    targetService.retrieveRecordedRequests(null).length must be(1)
+    targetService.retrieveRecordedRequests(null).length mustBe 1
     f(targetService.retrieveRecordedRequests(null)(0))
   }
 }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.MustMatchers
 import scala.collection.JavaConverters._
 
 class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with MustMatchers {
-  override def getMetaConfPath(): String = "src/test/resources/plugins/transformer/meta-config.json"
+  override def getMetaConfPath: String = "src/test/resources/plugins/transformer/meta-config.json"
 
   var targetService: ClientAndServer = _
 
@@ -104,7 +104,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getHeaders.asScala.toList.find(_.getName == "H").map(_.getValues.get(0)) must be (Some("value"))
+      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) must be (Some("value"))
     }
   }
 
@@ -117,7 +117,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getHeaders.asScala.toList.find(_.getName == "H").map(_.getValues.get(0)) must be (Some("value"))
+      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) must be (Some("value"))
     }
   }
 
@@ -131,12 +131,12 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req =>
-      req.getHeaders.asScala.toList.find(_.getName == "H").map(_.getValues.get(0)) must be (Some("value"))
+      req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) must be (Some("value"))
     }
   }
 
   def assertTargetRequest(f: HttpRequest => Unit): Unit = {
-    targetService.retrieveRecordedRequests(null).size must be(1)
+    targetService.retrieveRecordedRequests(null).length must be(1)
     f(targetService.retrieveRecordedRequests(null)(0))
   }
 }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -144,7 +144,15 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
     val envId = rand.nextInt.abs
 
     given()
-      .body(s"""{"scp":["env.$envId","payment.$paymentId","transfer.$transferId"],"groups":"admin"}""")
+      .body(
+        s"""{
+           |"scp": [
+           |  "env.$envId",
+           |  "payment_$paymentId",
+           |  "transfer.$transferId"
+           |],
+           |"groups": "admin"
+           |}""".stripMargin)
       .when()
       .get("/dyn-header-from-body")
       .`then`()

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -141,6 +141,8 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
     val rand = scala.util.Random
     val paymentId = rand.nextInt.abs
     val transferId = rand.nextInt.abs
+    val customerId = rand.nextInt.abs
+    val swiftId = rand.nextInt.abs
     val envId = rand.nextInt.abs
 
     given()
@@ -148,6 +150,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
         s"""{
            |"scp": [
            |  "env.($envId)",
+           |  "customer-{$customerId}_swift_$swiftId",
            |  "payment.[$paymentId]",
            |  "transfer.$transferId"
            |],
@@ -159,6 +162,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .statusCode(200)
 
     assertTargetRequest { req => getHeaderOnlyValue(req, "X-Scope") mustBe Some("elevated") }
+    assertTargetRequest { req => getHeaderOnlyValue(req, "X-Client") mustBe Some(s"$swiftId.$customerId") }
     assertTargetRequest { req => getHeaderOnlyValue(req, "X-SCP-Payment") mustBe Some(s"$paymentId") }
     assertTargetRequest { req => getHeaderOnlyValue(req, "X-SCP-Transfer") mustBe Some(s"$transferId") }
     assertTargetRequest { req => getHeaderOnlyValue(req, "DSKey") mustBe Some(s"$envId") }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -158,6 +158,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .`then`()
       .statusCode(200)
 
+    assertTargetRequest { req => getHeaderOnlyValue(req, "X-Scope") mustBe Some("elevated") }
     assertTargetRequest { req => getHeaderOnlyValue(req, "X-SCP-Payment") mustBe Some(s"$paymentId") }
     assertTargetRequest { req => getHeaderOnlyValue(req, "X-SCP-Transfer") mustBe Some(s"$transferId") }
     assertTargetRequest { req => getHeaderOnlyValue(req, "DSKey") mustBe Some(s"$envId") }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -147,8 +147,8 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
       .body(
         s"""{
            |"scp": [
-           |  "env.$envId",
-           |  "payment_$paymentId",
+           |  "env.($envId)",
+           |  "payment.[$paymentId]",
            |  "transfer.$transferId"
            |],
            |"groups": "admin"

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -143,7 +143,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
 
     given()
       .body(
-        s"""{"scp": ["unrelated-value-123", "transaction.$transactionId/swift.$swiftId"],"groups": "admin"}""".stripMargin)
+        s"""{"scp": ["unrelated-value-123", "transaction.$transactionId/swift.$swiftId"],"groups": "admin"}""")
       .when()
       .get("/dyn-header-can-find-multiple-params-and-reorder-them-in-output")
       .`then`()
@@ -159,7 +159,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
 
     given()
       .body(
-        s"""{"scp": ["unrelated-value-123", "(payment).is$$ok[$paymentId]?"],"groups": "admin"}""".stripMargin)
+        s"""{"scp": ["unrelated-value-123", "(payment).is$$ok[$paymentId]?"],"groups": "admin"}""")
       .when()
       .get("/dyn-header-matches-regex-special-chars-as-literals")
       .`then`()
@@ -175,7 +175,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
 
     given()
       .body(
-        s"""{"scp": ["unrelated-value-123", "customer-{$customerId}"],"groups": "admin"}""".stripMargin)
+        s"""{"scp": ["unrelated-value-123", "customer-{$customerId}"],"groups": "admin"}""")
       .when()
       .get("/dyn-header-can-match-curly-braces-when-doubled")
       .`then`()
@@ -185,13 +185,27 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
   }
 
   @Test
-  def shouldSetDynHeaderFromBodyAndAllowFixedMappingWhenPointedToNonArrayValue(): Unit = {
+  def shouldSetDynHeaderFromBodyAndAllowDynMappingWhenPointedToNonArrayValue(): Unit = {
     val rand = scala.util.Random
-    val customerId = rand.nextInt.abs
+    val envId = rand.nextInt.abs
 
     given()
       .body(
-        s"""{"scp": ["unrelated-value-123", "stuff"],"groups": "admin"}""".stripMargin)
+        s"""{"scp": ["unrelated-value-123", "stuff"],"env": "env.$envId"}""")
+      .when()
+      .get("/dyn-header-can-use-dyn-mapping-for-non-array-values")
+      .`then`()
+      .statusCode(200)
+
+    assertTargetRequest { req => getHeaderOnlyValue(req, "X-Env") mustBe Some(s"$envId") }
+  }
+
+  @Test
+  def shouldSetDynHeaderFromBodyAndAllowFixedMappingWhenPointedToNonArrayValue(): Unit = {
+
+    given()
+      .body(
+        s"""{"scp": ["unrelated-value-123", "stuff"],"groups": "admin"}""")
       .when()
       .get("/dyn-header-can-use-fixed-mapping-for-non-array-values")
       .`then`()

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginAcceptanceTest.scala
@@ -105,6 +105,7 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
 
     assertTargetRequest { req =>
       req.getHeaders.asScala.toList.find(_.getName.toString == "H").map(_.getValues.get(0)) mustBe Some("value")
+      // None was not equal to Some("value")
     }
   }
 

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginTest.scala
@@ -7,7 +7,7 @@ import com.cloudentity.tools.vertx.http.Headers
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.json.{JsonArray, JsonObject}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])
@@ -142,7 +142,7 @@ class TransformRequestPluginTest extends WordSpec with MustMatchers with TestReq
     }
   }
 
-  "TransformPathParams.set" should {
+  "TransformHeaders.set" should {
     val setHeaders = TransformHeaders.setHeaders _
 
     "set value for non-existing header" in {

--- a/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
+++ b/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
@@ -4,6 +4,7 @@ import com.cloudentity.pyron.domain.flow.{AuthnCtx, RequestCtx}
 import io.circe.Json
 import io.vertx.core.json.{JsonArray, JsonObject}
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 
@@ -44,6 +45,7 @@ trait ValueResolver {
       case HeaderRef(header, AllHeaderRefType)   => req.request.headers.getValues(header).map(_.foldLeft(new JsonArray())(_.add(_))).map(ArrayJsonValue) // returning JsonArray with all header values
     }
 
+  @tailrec
   private def extractBodyAttribute(body: JsonObject, path: Path): Option[JsonValue] =
     path.value match {
       case key :: Nil =>

--- a/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
+++ b/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
@@ -1,6 +1,6 @@
 package com.cloudentity.pyron.plugin.util.value
 
-import com.cloudentity.pyron.domain.flow.{AuthnCtx, PathMatching, RequestCtx}
+import com.cloudentity.pyron.domain.flow.{AuthnCtx, RequestCtx}
 import io.circe.Json
 import io.vertx.core.json.{JsonArray, JsonObject}
 
@@ -95,9 +95,7 @@ trait ValueResolver {
     }
 
   private def circeJsonDynString(req: RequestCtx, bodyOpt: Option[JsonObject], json: Json): Option[String] = {
-    val paramRegex = "\\{(\\w+)\\}".r
     for {
-      // FIX: maybe memoize steps below which only depend on config and not on req
       patternOpt <- json.hcursor.downField("pattern").focus
       patternStr <- patternOpt.asString
       outputOpt <- json.hcursor.downField("output").focus
@@ -105,17 +103,24 @@ trait ValueResolver {
       pathOpt <- json.hcursor.downField("path").focus
       valOrRef <- pathOpt.as[ValueOrRef].toOption
 
-      regexGroupNames = paramRegex.findAllMatchIn(patternStr).map(_.group(1))
-      regexWithGroups = paramRegex.replaceAllIn(s"^$patternStr$$", m => s"(?<${m.group(1)}>.+)")
+      regexGroupNames = """\{(\w+)}""".r.findAllMatchIn(patternStr).map(_.group(1))
+      regexWithParams = safeRegexWithParams(patternStr)
 
       jsonValue <- resolveJson(req, bodyOpt, valOrRef)
       candidates <- jsonValue.asListOfStrings
-      found <- candidates.find(v => v.matches(regexWithGroups))
-      matched <- regexWithGroups.r.findFirstMatchIn(found)
+      found <- candidates.find(v => v.matches(regexWithParams))
+      matched <- regexWithParams.r.findFirstMatchIn(found)
       keyvals = regexGroupNames.toList.zip(matched.subgroups)
     } yield keyvals.foldLeft(outputStr) {
       case (output, (key, value)) => output.replaceAllLiterally(s"{$key}", value)
     }
+  }
+
+  private def safeRegexWithParams(pattern: String): String = {
+    val paramRestoreRegex = """\\\{(\w+)\\}""".r
+    val sanitizerRegex = """([.*+?^${}()|\[\]\\])""".r
+    val regexSanitized = sanitizerRegex.replaceAllIn(pattern, v => """\\\""" + v.group(1))
+    paramRestoreRegex.replaceAllIn(s"^$regexSanitized$$", m => s"(?<${m.group(1)}>.+)")
   }
 
   private def circeJsonToJsonValue(json: Json): JsonValue = {

--- a/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
+++ b/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
@@ -168,7 +168,7 @@ trait ValueResolver {
   }
 
   private def normalizeParens(nonParamSlice: String): String = {
-    // this match will un-double all {{ and drop, single/odd { parens which are invalid
+    // this match will un-double all {{ and drop single/odd { parens which are invalid
     // since they could only precede param names, and nonParamSlice contains no params
     val normalizeParensRegex = """([{}])(?<dualParen>\1?)""".r
     normalizeParensRegex.replaceAllIn(nonParamSlice, _.group("dualParen"))

--- a/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
+++ b/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
@@ -129,10 +129,10 @@ trait ValueResolver {
 
   private def makeSafePatternAndParamList(pattern: String): (Regex, List[String]) = {
     val (paramNames, paramSlices) = findParamSlices(pattern)
-    val safePattern = ("" :: paramNames).zip(makeNonParamSlices(pattern, paramSlices))
+    val safePattern = "^" + ("" :: paramNames).zip(makeNonParamSlices(pattern, paramSlices))
       .map { case (paramName: String, followingSlice: String) =>
         if (paramName.nonEmpty) s"(?<$paramName>.+)" + followingSlice else followingSlice
-      }.mkString
+      }.mkString + "$"
     (safePattern.r, paramNames)
   }
 

--- a/pyron-plugin/src/test/scala/com/cloudentity/pyron/plugin/util/value/ValueResolverTest.scala
+++ b/pyron-plugin/src/test/scala/com/cloudentity/pyron/plugin/util/value/ValueResolverTest.scala
@@ -1,14 +1,12 @@
-package com.cloudentity.pyron.plugin.impl.transformer
+package com.cloudentity.pyron.plugin.util.value
 
 import com.cloudentity.pyron.domain.flow.{AuthnCtx, PathParams, RequestCtx}
-import com.cloudentity.pyron.plugin.util.value._
 import com.cloudentity.pyron.test.TestRequestResponseCtx
 import com.cloudentity.tools.vertx.http.Headers
 import io.circe.Json
-import io.vertx.core.buffer.Buffer
 import io.vertx.core.json.{JsonArray, JsonObject}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])


### PR DESCRIPTION
Pattern support for dynamic scopes is in place. Referenced values $body, $authn and so on are resolved.

Patters are sanitized: only {param} {id} {stuff} values will be captured and processed by regex, any other special regex sequences within patterns are escaped and treated literally. This means any and all chars can be matched as literals, including braces, slashes punctuation etc. Only { and } when placed around identifier are special since we use them to define capturing params. Curly braces can still be used as literal match chars. Just double them up -> {{ and }} will match literal curly braces { and }. Multiple parameters within match and parameters reordering is also supported. 

I will add more tests in TransformRequestPluginAcceptanceTest.scala show more of this functionality.

You can ignore/skip reading all other Test and Spec files. Pretty much the only change there is fix for deprecated import, which was throwing warnings:  import org.scalatestplus.junit.JUnitRunner.