### PR TITLE
SCMO-9568 Tests cleanup

### DIFF
--- a/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/QueryParamsSpec.scala
+++ b/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/QueryParamsSpec.scala
@@ -9,19 +9,19 @@ import org.scalatestplus.junit.JUnitRunner
 class QueryParamsSpec extends WordSpec with MustMatchers {
   "QueryParams.of" should {
     "construct instance from query string" in {
-      QueryParams.fromString("x=1&y=2") must be (Success(QueryParams(Map("x" -> List("1"), "y" -> List("2")))))
+      QueryParams.fromString("x=1&y=2") mustBe Success(QueryParams(Map("x" -> List("1"), "y" -> List("2"))))
     }
 
     "construct instance from query string with null values dropped if no name-value pair" in {
-      QueryParams.fromString("x") must be (Success(QueryParams(Map("x" -> List()))))
+      QueryParams.fromString("x") mustBe Success(QueryParams(Map("x" -> List())))
     }
 
     "construct instance from query string with null values dropped if multiple name-value pair" in {
-      QueryParams.fromString("x&x=1") must be (Success(QueryParams(Map("x" -> List("1")))))
+      QueryParams.fromString("x&x=1") mustBe Success(QueryParams(Map("x" -> List("1"))))
     }
 
     "construct instance from query string with multiple values per name" in {
-      QueryParams.fromString("x=1&x=2") must be (Success(QueryParams(Map("x" -> List("1", "2")))))
+      QueryParams.fromString("x=1&x=2") mustBe Success(QueryParams(Map("x" -> List("1", "2"))))
     }
   }
 
@@ -29,63 +29,63 @@ class QueryParamsSpec extends WordSpec with MustMatchers {
     val q = QueryParams(Map("x" -> List("1"), "y" -> List("2", "3")))
 
     "remove entry" in {
-      q.remove("x") must be (QueryParams(Map("y" -> List("2", "3"))))
+      q.remove("x") mustBe QueryParams(Map("y" -> List("2", "3")))
     }
 
     "remove value and entry if no more values for given name" in {
-      q.remove("x", "1") must be (QueryParams(Map("y" -> List("2", "3"))))
+      q.remove("x", "1") mustBe QueryParams(Map("y" -> List("2", "3")))
     }
 
     "remove value for given name" in {
-      q.remove("y", "2") must be (QueryParams(Map("x" -> List("1"), "y" -> List("3"))))
+      q.remove("y", "2") mustBe QueryParams(Map("x" -> List("1"), "y" -> List("3")))
     }
 
     "add value for missing name" in {
-      q.add("z", "4") must be (QueryParams(Map("x" -> List("1"), "y" -> List("2", "3"), "z" -> List("4"))))
+      q.add("z", "4") mustBe QueryParams(Map("x" -> List("1"), "y" -> List("2", "3"), "z" -> List("4")))
     }
 
     "add value for existing name" in {
-      q.add("x", "4") must be (QueryParams(Map("x" -> List("1", "4"), "y" -> List("2", "3"))))
+      q.add("x", "4") mustBe QueryParams(Map("x" -> List("1", "4"), "y" -> List("2", "3")))
     }
 
     "get None if missing name" in {
-      q.get("z") must be (None)
+      q.get("z") mustBe None
     }
 
     "get first value if multiple values from name" in {
-      q.get("y") must be (Some("2"))
+      q.get("y") mustBe Some("2")
     }
 
     "get all values for names" in {
-      q.getValues("y") must be (Some(List("2", "3")))
+      q.getValues("y") mustBe Some(List("2", "3"))
     }
 
     "set value for existing name" in {
-      q.set("y", "4") must be (QueryParams(Map("x" -> List("1"), "y" -> List("4"))))
+      q.set("y", "4") mustBe QueryParams(Map("x" -> List("1"), "y" -> List("4")))
     }
 
     "return false if does not contain given name" in {
-      q.contains("z") must be (false)
+      q.contains("z") mustBe false
     }
 
     "return true if contains given name" in {
-      q.contains("x") must be (true)
+      q.contains("x") mustBe true
     }
 
     "return false if does not contain given value for given name" in {
-      q.contains("x", "4") must be (false)
+      q.contains("x", "4") mustBe false
     }
 
     "return true if contains given value for given name" in {
-      q.contains("x", "1") must be (true)
+      q.contains("x", "1") mustBe true
     }
 
     "return true if entry exists" in {
-      q.exists(_._1 == "x") must be (true)
+      q.exists(_._1 == "x") mustBe true
     }
 
     "return false if entry does not exist" in {
-      q.exists(_._1 == "z") must be (false)
+      q.exists(_._1 == "z") mustBe false
     }
   }
 }

--- a/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/RelativeUriSpec.scala
+++ b/pyron-core/src/test/scala/com/cloudentity/pyron/domain/http/RelativeUriSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.{MustMatchers, WordSpec}
 class RelativeUriSpec extends WordSpec with MustMatchers {
   "RelativeUri" should {
     "encode query params" in {
-      FixedRelativeUri(UriPath("/path"), QueryParams("x" -> List("a a=")), PathParams(Map())).value must be("/path?x=a+a%3D")
+      FixedRelativeUri(UriPath("/path"), QueryParams("x" -> List("a a=")), PathParams(Map())).value mustBe "/path?x=a+a%3D"
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/VertxSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/VertxSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 trait VertxSpec extends FutureConversions {
   lazy val vertx: Vertx = Vertx.vertx()
-  implicit lazy val ec = VertxExecutionContext(this.vertx.getOrCreateContext())
+  implicit lazy val ec: VertxExecutionContext = VertxExecutionContext(this.vertx.getOrCreateContext())
 
   VertxBus.registerPayloadCodec(vertx.eventBus())
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ApiHandlerGroupsAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ApiHandlerGroupsAcceptanceTest.scala
@@ -187,10 +187,11 @@ class TestApiGroupsStore(apiGroups: List[ApiGroup]) extends ScalaServiceVerticle
 class ResponseHeaderPlugin extends ResponsePluginVerticle[Unit] {
   override def name: PluginName = PluginName("responseHeader")
 
-  override def apply(responseCtx: ResponseCtx, conf: Unit): Future[ResponseCtx] =
-    Future.successful {
-      responseCtx.modifyResponse(_.modifyHeaders(_.setHeaders(Map(getConfig().getString("headerName") -> getConfig().getString("headerValue")))))
-    }
+  override def apply(responseCtx: ResponseCtx, conf: Unit): Future[ResponseCtx] = Future.successful {
+    responseCtx.modifyResponse(_.modifyHeaders(_.setHeaders(
+      Map(getConfig.getString("headerName") -> getConfig.getString("headerValue"))
+    )))
+  }
 
   override def validate(conf: Unit): ValidateResponse = ValidateResponse.ok()
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ApplicationAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ApplicationAcceptanceTest.scala
@@ -11,9 +11,9 @@ import org.mockserver.model.HttpResponse.response
 import org.scalatest.MustMatchers
 
 class ApplicationAcceptanceTest extends PyronAcceptanceTest with MustMatchers with MockUtils {
-  override def getMetaConfPath() = "src/test/resources/acceptance/application/meta-config-min.json"
+  override def getMetaConfPath = "src/test/resources/acceptance/application/meta-config-min.json"
 
-  var targetService: ClientAndServer = null
+  var targetService: ClientAndServer = _
 
   @Before
   def before(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/BodyHandlingAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/BodyHandlingAcceptanceTest.scala
@@ -10,12 +10,12 @@ import org.mockserver.integration.ClientAndServer
 import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 
-class BodyHandlingAccesptanceTestextends extends PyronAcceptanceTest with MockUtils {
-  override def getMetaConfPath() = "src/test/resources/acceptance/body-handling/meta-config.json"
+class BodyHandlingAcceptanceTest extends PyronAcceptanceTest with MockUtils {
+  override def getMetaConfPath = "src/test/resources/acceptance/body-handling/meta-config.json"
 
-  var targetService: ClientAndServer = null
-  val body1024Bytes = List.fill(102)("abcdefghij").mkString("") + "abcd"
-  val body1025Bytes = body1024Bytes + "e"
+  var targetService: ClientAndServer = _
+  val body1024Bytes: String = List.fill(102)("abcdefghij").mkString("") + "abcd"
+  val body1025Bytes: String = body1024Bytes + "e"
 
   @Before
   def before(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/BodyHandlingAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/BodyHandlingAcceptanceTest.scala
@@ -35,16 +35,16 @@ class BodyHandlingAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
     given()
       .body(body1024Bytes)
-    .when()
+      .when()
       .post("/upload/buffer/limit")
-    .`then`()
+      .`then`()
       .statusCode(200)
 
     given()
       .body(body1025Bytes)
-    .when()
+      .when()
       .post("/upload/buffer/limit")
-    .`then`()
+      .`then`()
       .statusCode(413)
   }
 
@@ -56,16 +56,16 @@ class BodyHandlingAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
     given()
       .body(body1024Bytes)
-    .when()
+      .when()
       .post("/upload/stream/limit")
-    .`then`()
+      .`then`()
       .statusCode(200)
 
     given()
       .body(body1025Bytes)
-    .when()
+      .when()
       .post("/upload/stream/limit")
-    .`then`()
+      .`then`()
       .statusCode(413)
   }
 
@@ -83,9 +83,9 @@ class BodyHandlingAcceptanceTest extends PyronAcceptanceTest with MockUtils {
         ctx.assertEquals(200, resp.statusCode())
         async.complete()
       }.exceptionHandler{ ex =>
-        ctx.fail(ex)
-        async.complete()
-      }.end(body1024Bytes)
+      ctx.fail(ex)
+      async.complete()
+    }.end(body1024Bytes)
   }
 
   @Test

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ModifyRequestAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ModifyRequestAcceptanceTest.scala
@@ -17,9 +17,9 @@ import org.mockserver.model.HttpResponse.response
 import scala.concurrent.Future
 
 class ModifyResponseAcceptanceTest extends PyronAcceptanceTest with MockUtils {
-  override def getMetaConfPath(): String = "src/test/resources/acceptance/modify-response/meta-config-test.json"
+  override def getMetaConfPath: String = "src/test/resources/acceptance/modify-response/meta-config-test.json"
 
-    var targetService: ClientAndServer = null
+    var targetService: ClientAndServer = _
 
     @Before
   def before(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/OriginalRequestAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/OriginalRequestAcceptanceTest.scala
@@ -16,7 +16,7 @@ import org.junit.{After, Before, Test}
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.scalatest.MustMatchers
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 class OriginalRequestAcceptanceTest extends PyronAcceptanceTest with MustMatchers with MockUtils {
   var targetService: ClientAndServer = _
@@ -31,9 +31,9 @@ class OriginalRequestAcceptanceTest extends PyronAcceptanceTest with MustMatcher
     targetService.stop
   }
 
-  override def getMetaConfPath(): String = "src/test/resources/acceptance/original/meta-config.json"
+  override def getMetaConfPath: String = "src/test/resources/acceptance/original/meta-config.json"
 
-  val log = LoggerFactory.getLogger(this.getClass)
+  val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   @Test
   def shouldSetTargetRequestOriginalPathParamsAndQueryParamsAndMethod(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ProxyHeadersHandlerAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ProxyHeadersHandlerAcceptanceTest.scala
@@ -9,7 +9,6 @@ import com.cloudentity.pyron.domain.flow.ProxyHeaders
 import com.cloudentity.pyron.domain.http.Headers
 import io.circe.Json
 import io.circe.parser._
-import io.circe.syntax._
 import io.restassured.RestAssured.given
 import io.vertx.core.MultiMap
 import org.hamcrest.{BaseMatcher, Description}
@@ -17,9 +16,9 @@ import org.junit.Test
 import org.scalatest.MustMatchers
 
 class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMatchers {
-  override def getMetaConfPath(): String ="src/test/resources/acceptance/proxy-headers/meta-config.json"
+  override def getMetaConfPath: String ="src/test/resources/acceptance/proxy-headers/meta-config.json"
 
-  def headerMatcher(name: String, value: String) = new BaseMatcher[String] {
+  def headerMatcher(name: String, value: String): BaseMatcher[String] = new BaseMatcher[String] {
     override def matches(o: Any): Boolean =
       decode[Map[String, Json]](o.toString).toOption.flatMap(_.get("request")).flatMap(_.asObject).flatMap(_.toMap.get("headers")).get.as[Headers].toOption.get.get(name).contains(value)
 
@@ -59,7 +58,7 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
     )
     val expectedTrueClientIp = trueIp
 
-    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), false, headerNames) must be(ProxyHeaders(expectedHeaders, expectedTrueClientIp))
+    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
   }
 
   @Test
@@ -78,7 +77,7 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
       )
       val expectedTrueClientIp = trueIp
 
-      ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), false, headerNames) must be(ProxyHeaders(expectedHeaders, expectedTrueClientIp))
+      ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
     }
 
   @Test
@@ -97,7 +96,7 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
     )
     val expectedTrueClientIp = trueIp
 
-    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), false, headerNames) must be(ProxyHeaders(expectedHeaders, expectedTrueClientIp))
+    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
   }
 
   @Test
@@ -116,7 +115,7 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
     )
     val expectedTrueClientIp = trueIp
 
-    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), false, headerNames) must be(ProxyHeaders(expectedHeaders, expectedTrueClientIp))
+    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
   }
 
   @Test
@@ -134,7 +133,7 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
     )
     val expectedTrueClientIp = remoteIp
 
-    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), false, headerNames) must be(ProxyHeaders(expectedHeaders, expectedTrueClientIp))
+    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
   }
 
   @Test
@@ -153,6 +152,6 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
     )
     val expectedTrueClientIp = trueIp
 
-    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), false, headerNames) must be(ProxyHeaders(expectedHeaders, expectedTrueClientIp))
+    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/RulesReloadAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/RulesReloadAcceptanceTest.scala
@@ -7,7 +7,7 @@ import io.vertx.core.json.{JsonArray, JsonObject}
 import org.junit.Test
 
 class RulesReloadAcceptanceTest extends PyronAcceptanceTest with MockUtils {
-  override def getMetaConfPath(): String = "src/test/resources/acceptance/rules-reload/meta-config.json"
+  override def getMetaConfPath: String = "src/test/resources/acceptance/rules-reload/meta-config.json"
 
   @Test
   def shouldReloadRulesArray(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/SmartTargetClientsReloadAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/SmartTargetClientsReloadAcceptanceTest.scala
@@ -10,10 +10,10 @@ import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.mockserver.model.HttpResponse
 
 class SmartTargetClientsReloadAcceptanceTest extends PyronAcceptanceTest with MockUtils {
-  override def getMetaConfPath(): String = "src/test/resources/acceptance/smart-clients-reload/meta-config.json"
+  override def getMetaConfPath: String = "src/test/resources/acceptance/smart-clients-reload/meta-config.json"
 
-  var targetServiceA: ClientAndServer = null
-  var targetServiceB: ClientAndServer = null
+  var targetServiceA: ClientAndServer = _
+  var targetServiceB: ClientAndServer = _
 
   @Before
   def before(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TargetClientWithSmartHttpAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TargetClientWithSmartHttpAcceptanceTest.scala
@@ -161,7 +161,11 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
     val httpRequest = io.restassured.RestAssured.given.header("a", "1", "2", "3")
     val httpResponse = httpRequest.post("/discoverable-service/test")
 
-    Assert.assertEquals(List(new RestHeader("b", "4"), new RestHeader("b", "5")).asJava, httpResponse.headers().getList("b"))
+    Assert.assertEquals(List(
+      new RestHeader("b", "4"),
+      new RestHeader("b", "5")).asJava,
+      httpResponse.headers().getList("b")
+    )
     Assert.assertEquals(200, httpResponse.statusCode())
   }
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TargetClientWithSmartHttpAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TargetClientWithSmartHttpAcceptanceTest.scala
@@ -27,11 +27,11 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
     targetService.stop
   }
 
-  override def getMetaConfPath(): String = "src/test/resources/acceptance/http/meta-config.json"
+  override def getMetaConfPath: String = "src/test/resources/acceptance/http/meta-config.json"
 
   @Test
   def targetClientUsingSmartHttpClientShouldProxyHeadersAndBodyAndSetInternalJwtHeader(): Unit = {
-    // given
+
     val requestHeaders = Map("x" -> "y", "z" -> "w")
     val requestBody = "body"
 
@@ -48,20 +48,18 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
           .withHeader(targetResponseHeaderKey, targetResponseHeaderValue)
       )
 
-    // when
     given()
       .headers(requestHeaders.asJava)
       .body(requestBody)
     .when()
       .post("/discoverable-service/test")
-    // then
     .`then`()
       .statusCode(200)
       .header(targetResponseHeaderKey, targetResponseHeaderValue)
       .body(IsEqual.equalTo(targetResponseBody))
 
     val requests = targetService.retrieveRecordedRequests(null)
-    requests.size mustBe(1)
+    requests.size mustBe 1
 
     targetService.verify(
       request()
@@ -72,7 +70,6 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
 
   @Test
   def targetClientUsingSmartHttpClientWithServiceTagsShouldCallTargetService(): Unit = {
-    // given
     val requestBody = "body"
 
     targetService
@@ -83,18 +80,16 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
           .withBody(requestBody)
       )
 
-    // when
     given()
       .body(requestBody)
     .when()
       .post("/discoverable-service-with-tags/test")
-      // then
     .`then`()
       .statusCode(200)
       .body(IsEqual.equalTo(requestBody))
 
     val requests = targetService.retrieveRecordedRequests(null)
-    requests.size mustBe(1)
+    requests.size mustBe 1
 
     targetService.verify(
       request()
@@ -104,7 +99,6 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
 
   @Test
   def targetClientUsingSmartHttpClientWithDefaultConfigShouldCallTargetService(): Unit = {
-    // given
     val requestBody = "body"
 
     targetService
@@ -115,18 +109,16 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
           .withBody(requestBody)
       )
 
-    // when
     given()
       .body(requestBody)
-      .when()
+    .when()
       .post("/service-default-config/test")
-      // then
-      .`then`()
+    .`then`()
       .statusCode(400)
       .body(IsEqual.equalTo(requestBody))
 
     val requests = targetService.retrieveRecordedRequests(null)
-    requests.size mustBe(2)
+    requests.size mustBe 2
 
     targetService.verify(
       request()
@@ -148,18 +140,16 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
           .withBody(requestBody)
       )
 
-    // when
     given()
       .body(requestBody)
     .when()
       .post("/static-service/test")
-    // then
     .`then`()
       .statusCode(504)
       .body(StringContains.containsString("Response.Timeout"))
 
     val requests = targetService.retrieveRecordedRequests(null)
-    requests.size mustBe(1)
+    requests.size mustBe 1
   }
 
   @Test

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TransferEncodingAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TransferEncodingAcceptanceTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.scalatest.MustMatchers
 
 class TransferEncodingAcceptanceTest extends PyronAcceptanceTest with MustMatchers {
-  override def getMetaConfPath(): String = "src/test/resources/acceptance/transfer-encoding/meta-config.json"
+  override def getMetaConfPath: String = "src/test/resources/acceptance/transfer-encoding/meta-config.json"
 
   @Test
   def shouldNotSetContentLengthHeaderWhenApiResponseHasTransferEncodignChunkedHeader(): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupConflictsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupConflictsSpec.scala
@@ -1,5 +1,6 @@
 package com.cloudentity.pyron.apigroup
 
+import com.cloudentity.pyron.apigroup.ApiGroupConflicts.isConflicted
 import com.cloudentity.pyron.domain.flow.{BasePath, DomainPattern, GroupMatchCriteria}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
@@ -9,67 +10,67 @@ import org.scalatest.{MustMatchers, WordSpec}
 class ApiGroupConflictsSpec extends WordSpec with MustMatchers {
   "ApiGroupConflicts.isConflicted" should {
     "return true when domains empty and base-path the same" in {
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(None, None)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, None)) must be (true)
+      isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))) mustBe true
+      isConflicted(GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(None, None)) mustBe true
+      isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, None)) mustBe true
     }
 
     "return true when domains the same and base-path the same" in {
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, None)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/path")), None), GroupMatchCriteria(Some(BasePath("/path")), None)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com")))), GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com"))))) must be (true)
+      isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, None)) mustBe true
+      isConflicted(GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))) mustBe true
+      isConflicted(GroupMatchCriteria(Some(BasePath("/path")), None), GroupMatchCriteria(Some(BasePath("/path")), None)) mustBe true
+      isConflicted(GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com")))), GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com"))))) mustBe true
     }
 
     "return true when domains overlapping and base-path empty" in {
       val emptyBasePath = None
 
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com"))))) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))) must be (true)
+      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com"))))) mustBe true
+      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))) mustBe true
+      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))) mustBe true
     }
 
     "return false when domains overlapping and base-path not prefixed" in {
       val domains1 = Some(List(DomainPattern("*.com")))
       val domains2 = Some(List(DomainPattern("x.com")))
 
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/a")), domains1), GroupMatchCriteria(Some(BasePath("/b")), domains2)) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/b")), domains1), GroupMatchCriteria(Some(BasePath("/a")), domains2)) must be (false)
+      isConflicted(GroupMatchCriteria(Some(BasePath("/a")), domains1), GroupMatchCriteria(Some(BasePath("/b")), domains2)) mustBe false
+      isConflicted(GroupMatchCriteria(Some(BasePath("/b")), domains1), GroupMatchCriteria(Some(BasePath("/a")), domains2)) mustBe false
     }
 
     "return false when domains do not overlap and base-path empty" in {
       val emptyBasePath = None
 
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("y.x.com"))))) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.org"))))) must be (false)
+      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("y.x.com"))))) mustBe false
+      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.org"))))) mustBe false
     }
 
     "return true when domains empty and base-path prefixed" in {
       val emptyDomains = None
 
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(None, emptyDomains)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains)) must be (true)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) must be (true)
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) mustBe true
+      isConflicted(GroupMatchCriteria(None, emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) mustBe true
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(None, emptyDomains)) mustBe true
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains)) mustBe true
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) mustBe true
     }
 
     "return false when domains empty and base-path not prefixed" in {
       val emptyDomains = None
 
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/a")), emptyDomains), GroupMatchCriteria(Some(BasePath("/b")), emptyDomains)) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/b")), emptyDomains), GroupMatchCriteria(Some(BasePath("/a")), emptyDomains)) must be (false)
+      isConflicted(GroupMatchCriteria(Some(BasePath("/a")), emptyDomains), GroupMatchCriteria(Some(BasePath("/b")), emptyDomains)) mustBe false
+      isConflicted(GroupMatchCriteria(Some(BasePath("/b")), emptyDomains), GroupMatchCriteria(Some(BasePath("/a")), emptyDomains)) mustBe false
     }
 
     "return false when domains do not overlap and base-path prefixed" in {
       val domains1 = Some(List(DomainPattern("*.com")))
       val domains2 = Some(List(DomainPattern("*.org")))
 
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(None, domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(None, domains2)) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(Some(BasePath("/x/y")), domains2)) must be (false)
-      ApiGroupConflicts.isConflicted(GroupMatchCriteria(Some(BasePath("/x/y")), domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) must be (false)
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) mustBe false
+      isConflicted(GroupMatchCriteria(None, domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) mustBe false
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(None, domains2)) mustBe false
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(Some(BasePath("/x/y")), domains2)) mustBe false
+      isConflicted(GroupMatchCriteria(Some(BasePath("/x/y")), domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) mustBe false
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupConflictsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupConflictsSpec.scala
@@ -10,67 +10,145 @@ import org.scalatest.{MustMatchers, WordSpec}
 class ApiGroupConflictsSpec extends WordSpec with MustMatchers {
   "ApiGroupConflicts.isConflicted" should {
     "return true when domains empty and base-path the same" in {
-      isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))) mustBe true
-      isConflicted(GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(None, None)) mustBe true
-      isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, None)) mustBe true
+      isConflicted(
+        GroupMatchCriteria(None, None),
+        GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(None, None)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(None, None),
+        GroupMatchCriteria(None, None)
+      ) mustBe true
     }
 
     "return true when domains the same and base-path the same" in {
-      isConflicted(GroupMatchCriteria(None, None), GroupMatchCriteria(None, None)) mustBe true
-      isConflicted(GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))) mustBe true
-      isConflicted(GroupMatchCriteria(Some(BasePath("/path")), None), GroupMatchCriteria(Some(BasePath("/path")), None)) mustBe true
-      isConflicted(GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com")))), GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com"))))) mustBe true
+      isConflicted(
+        GroupMatchCriteria(None, None),
+        GroupMatchCriteria(None, None)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(None, Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/path")), None),
+        GroupMatchCriteria(Some(BasePath("/path")), None)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(Some(BasePath("/path")), Some(List(DomainPattern("*.com"))))
+      ) mustBe true
     }
 
     "return true when domains overlapping and base-path empty" in {
       val emptyBasePath = None
 
-      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com"))))) mustBe true
-      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))) mustBe true
-      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))) mustBe true
+      isConflicted(
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com"))))
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com")))),
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("x.com"))))
+      ) mustBe true
     }
 
     "return false when domains overlapping and base-path not prefixed" in {
       val domains1 = Some(List(DomainPattern("*.com")))
       val domains2 = Some(List(DomainPattern("x.com")))
 
-      isConflicted(GroupMatchCriteria(Some(BasePath("/a")), domains1), GroupMatchCriteria(Some(BasePath("/b")), domains2)) mustBe false
-      isConflicted(GroupMatchCriteria(Some(BasePath("/b")), domains1), GroupMatchCriteria(Some(BasePath("/a")), domains2)) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/a")), domains1),
+        GroupMatchCriteria(Some(BasePath("/b")), domains2)
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/b")), domains1),
+        GroupMatchCriteria(Some(BasePath("/a")), domains2)
+      ) mustBe false
     }
 
     "return false when domains do not overlap and base-path empty" in {
       val emptyBasePath = None
 
-      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("y.x.com"))))) mustBe false
-      isConflicted(GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))), GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.org"))))) mustBe false
+      isConflicted(
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("y.x.com"))))
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.com")))),
+        GroupMatchCriteria(emptyBasePath, Some(List(DomainPattern("*.org"))))
+      ) mustBe false
     }
 
     "return true when domains empty and base-path prefixed" in {
       val emptyDomains = None
 
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) mustBe true
-      isConflicted(GroupMatchCriteria(None, emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) mustBe true
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(None, emptyDomains)) mustBe true
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains)) mustBe true
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains), GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)) mustBe true
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x")), emptyDomains),
+        GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(None, emptyDomains),
+        GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x")), emptyDomains),
+        GroupMatchCriteria(None, emptyDomains)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x")), emptyDomains),
+        GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains)
+      ) mustBe true
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x/y")), emptyDomains),
+        GroupMatchCriteria(Some(BasePath("/x")), emptyDomains)
+      ) mustBe true
     }
 
     "return false when domains empty and base-path not prefixed" in {
       val emptyDomains = None
 
-      isConflicted(GroupMatchCriteria(Some(BasePath("/a")), emptyDomains), GroupMatchCriteria(Some(BasePath("/b")), emptyDomains)) mustBe false
-      isConflicted(GroupMatchCriteria(Some(BasePath("/b")), emptyDomains), GroupMatchCriteria(Some(BasePath("/a")), emptyDomains)) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/a")), emptyDomains),
+        GroupMatchCriteria(Some(BasePath("/b")), emptyDomains)
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/b")), emptyDomains),
+        GroupMatchCriteria(Some(BasePath("/a")), emptyDomains)
+      ) mustBe false
     }
 
     "return false when domains do not overlap and base-path prefixed" in {
       val domains1 = Some(List(DomainPattern("*.com")))
       val domains2 = Some(List(DomainPattern("*.org")))
 
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) mustBe false
-      isConflicted(GroupMatchCriteria(None, domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) mustBe false
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(None, domains2)) mustBe false
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x")), domains1), GroupMatchCriteria(Some(BasePath("/x/y")), domains2)) mustBe false
-      isConflicted(GroupMatchCriteria(Some(BasePath("/x/y")), domains1), GroupMatchCriteria(Some(BasePath("/x")), domains2)) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x")), domains1),
+        GroupMatchCriteria(Some(BasePath("/x")), domains2)
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(None, domains1),
+        GroupMatchCriteria(Some(BasePath("/x")), domains2)
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x")), domains1),
+        GroupMatchCriteria(None, domains2)
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x")), domains1),
+        GroupMatchCriteria(Some(BasePath("/x/y")), domains2)
+      ) mustBe false
+      isConflicted(
+        GroupMatchCriteria(Some(BasePath("/x/y")), domains1),
+        GroupMatchCriteria(Some(BasePath("/x")), domains2)
+      ) mustBe false
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupReaderSpec.scala
@@ -21,10 +21,10 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |}""".stripMargin
 
       val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
           Nil,
-          ApiGroupLevel(None, Some(group), Nil, Nil)
+          ApiGroupLevel(rules = None, group = Some(group), plugins = Nil, subs = Nil)
         )
       }
     }
@@ -41,10 +41,10 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |}""".stripMargin
 
       val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
           Nil,
-          ApiGroupLevel(Some(Json.obj()), Some(group), Nil, Nil)
+          ApiGroupLevel(rules = Some(Json.obj()), group = Some(group), plugins = Nil, subs = Nil)
         )
       }
     }
@@ -62,14 +62,14 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |}""".stripMargin
 
       val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
-          Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
                 List("service-a"),
                 ApiGroupLevel(None, Some(group), Nil, Nil)
@@ -99,17 +99,17 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |}""".stripMargin
 
       val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
-          Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
-                List("service-a"),
-                ApiGroupLevel(None, Some(group), List(ApiGroupPlugin(PluginName("authn"), PluginId("service-a"))), Nil)
+                path = List("service-a"),
+                value = ApiGroupLevel(None, Some(group), List(ApiGroupPlugin(PluginName("authn"), PluginId("service-a"))), Nil)
               )
             )
           )
@@ -131,16 +131,17 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |}""".stripMargin
 
       val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
-        ValidResult(Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
+        ValidResult(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
-                List("service-a"),
-                ApiGroupLevel(Some(Json.obj()), Some(group), Nil, Nil)
+                path = List("service-a"),
+                value = ApiGroupLevel(Some(Json.obj()), Some(group), Nil, Nil)
               )
             )
           )
@@ -163,24 +164,24 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |}""".stripMargin
 
       val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
-          Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
-                List("level-a"),
-                ApiGroupLevel(
-                  None,
-                  None,
-                  Nil,
-                  List(
+                path = List("level-a"),
+                value = ApiGroupLevel(
+                  rules = None,
+                  group = None,
+                  plugins = Nil,
+                  subs = List(
                     ValidResult(
-                      List("service-a", "level-a"),
-                      ApiGroupLevel(None, Some(group), Nil, Nil)
+                      path = List("service-a", "level-a"),
+                      value = ApiGroupLevel(None, Some(group), Nil, Nil)
                     )
                   )
                 )
@@ -202,25 +203,24 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
                    |  }
                    |}""".stripMargin
 
-      val group = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
-          Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
-                List("level-a"),
-                ApiGroupLevel(
-                  None,
-                  None,
-                  Nil,
-                  List(
+                path = List("level-a"),
+                value = ApiGroupLevel(
+                  rules = None,
+                  group = None,
+                  plugins = Nil,
+                  subs = List(
                     InvalidResult(
-                      List("service-a", "level-a"),
-                      "Invalid group level at 'level-a.service-a._group.basePath'"
+                      path = List("service-a", "level-a"),
+                      msg = "Invalid group level at 'level-a.service-a._group.basePath'"
                     )
                   )
                 )
@@ -253,24 +253,24 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
 
       val group1 = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
       val group2 = GroupMatchCriteria(Some(BasePath("/y")), Some(List(DomainPattern("2.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
-          Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
-                List("level-a"),
-                ApiGroupLevel(
-                  None,
-                  Some(group1),
-                  Nil,
-                  List(
+                path = List("level-a"),
+                value = ApiGroupLevel(
+                  rules = None,
+                  group = Some(group1),
+                  plugins = Nil,
+                  subs = List(
                     ValidResult(
-                      List("service-a", "level-a"),
-                      ApiGroupLevel(None, Some(group2), Nil, Nil)
+                      path = List("service-a", "level-a"),
+                      value = ApiGroupLevel(None, Some(group2), Nil, Nil)
                     )
                   )
                 )
@@ -305,28 +305,28 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
 
       val group1 = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
       val group2 = GroupMatchCriteria(Some(BasePath("/y")), Some(List(DomainPattern("2.com"))))
-      ApiGroupReader.readApiGroupLevels(json) must be {
+      ApiGroupReader.readApiGroupLevels(json) mustBe {
         ValidResult(
-          Nil,
-          ApiGroupLevel(
-            None,
-            None,
-            Nil,
-            List(
+          path = Nil,
+          value = ApiGroupLevel(
+            rules = None,
+            group = None,
+            plugins = Nil,
+            subs = List(
               ValidResult(
-                List("level-a"),
-                ApiGroupLevel(
-                  None,
-                  None,
-                  Nil,
-                  List(
+                path = List("level-a"),
+                value = ApiGroupLevel(
+                  rules = None,
+                  group = None,
+                  plugins = Nil,
+                  subs = List(
                     ValidResult(
-                      List("service-a", "level-a"),
-                      ApiGroupLevel(None, Some(group1), Nil, Nil)
+                      path = List("service-a", "level-a"),
+                      value = ApiGroupLevel(None, Some(group1), Nil, Nil)
                     ),
                     ValidResult(
-                      List("service-b", "level-a"),
-                      ApiGroupLevel(None, Some(group2), Nil, Nil)
+                      path = List("service-b", "level-a"),
+                      value = ApiGroupLevel(None, Some(group2), Nil, Nil)
                     )
                   )
                 )
@@ -374,28 +374,38 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
 
     val group1 = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
     val group2 = GroupMatchCriteria(Some(BasePath("/y")), Some(List(DomainPattern("2.com"))))
-    ApiGroupReader.readApiGroupLevels(json) must be {
+    ApiGroupReader.readApiGroupLevels(json) mustBe {
       ValidResult(
-        Nil,
-        ApiGroupLevel(
-          None,
-          None,
-          Nil,
-          List(
+        path = Nil,
+        value = ApiGroupLevel(
+          rules = None,
+          group = None,
+          plugins = Nil,
+          subs = List(
             ValidResult(
-              List("level-a"),
-              ApiGroupLevel(
-                None,
-                None,
-                Nil,
-                List(
+              path = List("level-a"),
+              value = ApiGroupLevel(
+                rules = None,
+                group = None,
+                plugins = Nil,
+                subs = List(
                   ValidResult(
-                    List("service-a", "level-a"),
-                    ApiGroupLevel(None, Some(group1), List(ApiGroupPlugin(PluginName("authn"), PluginId("level-a-service-a"))), Nil)
+                    path = List("service-a", "level-a"),
+                    value = ApiGroupLevel(
+                      rules = None,
+                      group = Some(group1),
+                      plugins = List(ApiGroupPlugin(PluginName("authn"), PluginId("level-a-service-a"))),
+                      subs = Nil
+                    )
                   ),
                   ValidResult(
-                    List("service-b", "level-a"),
-                    ApiGroupLevel(None, Some(group2), List(ApiGroupPlugin(PluginName("authn"), PluginId("level-a-service-b"))), Nil)
+                    path = List("service-b", "level-a"),
+                    value = ApiGroupLevel(
+                      rules = None,
+                      group = Some(group2),
+                      plugins = List(ApiGroupPlugin(PluginName("authn"), PluginId("level-a-service-b"))),
+                      subs = Nil
+                    )
                   )
                 )
               )
@@ -410,61 +420,65 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
     "build 0-level" in {
       val criteria = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
 
-      val level =
-        ApiGroupLevel(
-          Some(Json.arr()),
-          Some(criteria),
-          Nil,
-          Nil
-        )
+      val level = ApiGroupLevel(
+        rules = Some(Json.arr()),
+        group = Some(criteria),
+        plugins = Nil,
+        subs = Nil
+      )
 
-      val group = ApiGroupConfUnresolved(criteria, Json.arr(), Nil)
+      val group = ApiGroupConfUnresolved(matchCriteria = criteria, rules = Json.arr(), plugins = Nil)
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level)must be (List(ValidResult(Nil, group)))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(ValidResult(path = Nil, value = group))
     }
 
     "build 1-level with inherited basePath" in {
       val group0 = GroupMatchCriteria(Some(BasePath("/x")), None)
       val group1 = GroupMatchCriteria(Some(BasePath("/y")), None)
 
-      val level =
-        ApiGroupLevel(
-          None,
-          Some(group0),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr()), Some(group1), Nil, Nil)
-            )
+      val level = ApiGroupLevel(
+        rules = None,
+        group = Some(group0),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr()), Some(group1), Nil, Nil)
           )
         )
+      )
 
       val group = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x/y")), None), Json.arr(), Nil)
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level) must be (List(ValidResult(List("y"), group)))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(ValidResult(List("y"), group))
     }
 
     "build 1-level with inherited domains" in {
       val group0 = GroupMatchCriteria(None, Some(List(DomainPattern("*.com"))))
       val group1 = GroupMatchCriteria(Some(BasePath("/x")), None)
 
-      val level =
-        ApiGroupLevel(
-          None,
-          Some(group0),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr()), Some(group1), Nil, Nil)
-            )
+      val level = ApiGroupLevel(
+        rules = None,
+        group = Some(group0),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr()), Some(group1), Nil, Nil)
           )
         )
+      )
 
-      val group = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("*.com")))), Json.arr(), Nil)
+      val group = ApiGroupConfUnresolved(
+        matchCriteria = GroupMatchCriteria(
+          basePath = Some(BasePath("/x")),
+          domains = Some(List(DomainPattern("*.com")))
+        ),
+        rules = Json.arr(),
+        plugins = Nil
+      )
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level) must be (List(ValidResult(List("y"), group)))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(ValidResult(List("y"), group))
     }
 
     "build 1-level with aggregated sub-level failures" in {
@@ -473,104 +487,126 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
       val group1b = GroupMatchCriteria(Some(BasePath("/w")), None)
       val group1c = GroupMatchCriteria(Some(BasePath("/w1")), None)
 
-      val level =
-        ApiGroupLevel(
-          None,
-          Some(group0),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-y"))), Some(group1a), Nil, Nil)
-            ),
-            ValidResult(
-              List("z"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-z"))), Some(group1a), Nil, Nil)
-            ),
-            ValidResult(
-              List("w"),
-              ApiGroupLevel(
-                None,
-                Some(group1b),
-                Nil,
-                List(
-                  InvalidResult(List("w", "w0"), "invalid"),
-                  ValidResult(List("w", "w1"), ApiGroupLevel(Some(Json.arr(Json.fromString("rules-w1"))), Some(group1c), Nil, Nil))
+      val level = ApiGroupLevel(
+        rules = None,
+        group = Some(group0),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-y"))), Some(group1a), Nil, Nil)
+          ),
+          ValidResult(
+            path = List("z"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-z"))), Some(group1a), Nil, Nil)
+          ),
+          ValidResult(
+            path = List("w"),
+            value = ApiGroupLevel(
+              rules = None,
+              group = Some(group1b),
+              plugins = Nil,
+              subs = List(
+                InvalidResult(path = List("w", "w0"), msg = "invalid"),
+                ValidResult(
+                  path = List("w", "w1"),
+                  value = ApiGroupLevel(
+                    rules = Some(Json.arr(Json.fromString("rules-w1"))),
+                    group = Some(group1c),
+                    plugins = Nil,
+                    subs = Nil
+                  )
                 )
               )
             )
           )
         )
+      )
 
-      val groupA = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x")), None), Json.arr(Json.fromString("rules-y"), Json.fromString("rules-z")), Nil)
-      val groupC = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x/w/w1")), None), Json.arr(Json.fromString("rules-w1")), Nil)
+      val groupA = ApiGroupConfUnresolved(
+        matchCriteria = GroupMatchCriteria(Some(BasePath("/x")), None),
+        rules = Json.arr(Json.fromString("rules-y"), Json.fromString("rules-z")),
+        plugins = Nil
+      )
+      val groupC = ApiGroupConfUnresolved(
+        matchCriteria = GroupMatchCriteria(Some(BasePath("/x/w/w1")), None),
+        rules = Json.arr(Json.fromString("rules-w1")),
+        plugins = Nil
+      )
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level) must be(List(ValidResult(List(), groupA), ValidResult(List("w", "w1"), groupC), InvalidResult(List("w", "w0"), "invalid")))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(
+        ValidResult(List(), groupA),
+        ValidResult(List("w", "w1"), groupC),
+        InvalidResult(List("w", "w0"), "invalid")
+      )
     }
 
     "fail to build 1-level with overwritten domains" in {
       val group0 = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("*.com"))))
       val group1 = GroupMatchCriteria(None, Some(List(DomainPattern("y.com"))))
 
-      val level =
-        ApiGroupLevel(
-          None,
-          Some(group0),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr()), Some(group1), Nil, Nil)
-            )
+      val level = ApiGroupLevel(
+        rules = None,
+        group = Some(group0),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr()), Some(group1), Nil, Nil)
           )
         )
+      )
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level) must be (List(InvalidResult(List("y"), "leaf node with domains set can't inherit them from parent")))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(
+        InvalidResult(List("y"), "leaf node with domains set can't inherit them from parent")
+      )
     }
 
     "fail to build 0-level with both rules and sub-levels set" in {
       val criteria = GroupMatchCriteria(Some(BasePath("/x")), Some(List(DomainPattern("1.com"))))
 
-      val level =
-        ApiGroupLevel(
-          Some(Json.arr()),
-          Some(criteria),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr()), None, Nil, Nil)
-            )
+      val level = ApiGroupLevel(
+        rules = Some(Json.arr()),
+        group = Some(criteria),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr()), None, Nil, Nil)
           )
         )
+      )
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level)must be (List(InvalidResult(Nil, "leaf node with rules can't have sub-levels")))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(InvalidResult(Nil, "leaf node with rules can't have sub-levels"))
     }
 
     "build 1-level with merged rules" in {
       val group0 = GroupMatchCriteria(Some(BasePath("/x")), None)
       val group1 = GroupMatchCriteria(None, None)
 
-      val level =
-        ApiGroupLevel(
-          None,
-          Some(group0),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-y"))), Some(group1), Nil, Nil)
-            ),
-            ValidResult(
-              List("z"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-z"))), Some(group1), Nil, Nil)
-            )
+      val level = ApiGroupLevel(
+        rules = None,
+        group = Some(group0),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-y"))), Some(group1), Nil, Nil)
+          ),
+          ValidResult(
+            path = List("z"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-z"))), Some(group1), Nil, Nil)
           )
         )
+      )
 
-      val group = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x")), None), Json.arr(Json.fromString("rules-y"), Json.fromString("rules-z")), Nil)
+      val group = ApiGroupConfUnresolved(
+        matchCriteria = GroupMatchCriteria(Some(BasePath("/x")), None),
+        rules = Json.arr(Json.fromString("rules-y"), Json.fromString("rules-z")),
+        plugins = Nil
+      )
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level) must be(List(ValidResult(List(), group)))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(ValidResult(List(), group))
     }
 
     "build 1-level with/wo merged rules" in {
@@ -578,31 +614,38 @@ class ApiGroupReaderSpec extends WordSpec with MustMatchers {
       val group1a = GroupMatchCriteria(None, None)
       val group1b = GroupMatchCriteria(Some(BasePath("/w")), None)
 
-      val level =
-        ApiGroupLevel(
-          None,
-          Some(group0),
-          Nil,
-          List(
-            ValidResult(
-              List("y"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-y"))), Some(group1a), Nil, Nil)
-            ),
-            ValidResult(
-              List("z"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-z"))), Some(group1a), Nil, Nil)
-            ),
-            ValidResult(
-              List("w"),
-              ApiGroupLevel(Some(Json.arr(Json.fromString("rules-w"))), Some(group1b), Nil, Nil)
-            )
+      val level = ApiGroupLevel(
+        rules = None,
+        group = Some(group0),
+        plugins = Nil,
+        subs = List(
+          ValidResult(
+            path = List("y"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-y"))), Some(group1a), Nil, Nil)
+          ),
+          ValidResult(
+            path = List("z"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-z"))), Some(group1a), Nil, Nil)
+          ),
+          ValidResult(
+            path = List("w"),
+            value = ApiGroupLevel(Some(Json.arr(Json.fromString("rules-w"))), Some(group1b), Nil, Nil)
           )
         )
+      )
 
-      val groupA = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x")), None), Json.arr(Json.fromString("rules-y"), Json.fromString("rules-z")), Nil)
-      val groupB = ApiGroupConfUnresolved(GroupMatchCriteria(Some(BasePath("/x/w")), None), Json.arr(Json.fromString("rules-w")), Nil)
+      val groupA = ApiGroupConfUnresolved(
+        matchCriteria = GroupMatchCriteria(Some(BasePath("/x")), None),
+        rules = Json.arr(Json.fromString("rules-y"), Json.fromString("rules-z")),
+        plugins = Nil
+      )
+      val groupB = ApiGroupConfUnresolved(
+        matchCriteria = GroupMatchCriteria(Some(BasePath("/x/w")), None),
+        rules = Json.arr(Json.fromString("rules-w")),
+        plugins = Nil
+      )
 
-      ApiGroupReader.buildApiGroupConfsUnresolved(level) must be(List(ValidResult(List(), groupA), ValidResult(List("w"), groupB)))
+      ApiGroupReader.buildApiGroupConfsUnresolved(level) mustBe List(ValidResult(List(), groupA), ValidResult(List("w"), groupB))
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupsStoreVerticleSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ApiGroupsStoreVerticleSpec.scala
@@ -1,7 +1,7 @@
 package com.cloudentity.pyron.apigroup
 
 import com.cloudentity.pyron.rule.RulesStoreVerticle
-import com.cloudentity.tools.vertx.bus.ServiceClientFactory
+import com.cloudentity.tools.vertx.bus.VertxEndpointClient
 import com.cloudentity.tools.vertx.conf.ConfVerticleDeploy
 import com.cloudentity.tools.vertx.test.VertxUnitTest
 import com.cloudentity.tools.vertx.verticles.VertxDeploy
@@ -54,6 +54,6 @@ class ApiGroupsStoreVerticleSpec extends VertxUnitTest {
       .compose(_ => init)
       .compose { _ => VertxDeploy.deploy(vertx, new RulesStoreVerticle) }
       .compose { _ => VertxDeploy.deploy(vertx, new ApiGroupsStoreVerticle) }
-      .compose { _ => VxFuture.succeededFuture(ServiceClientFactory.make(vertx.eventBus(), classOf[ApiGroupsStore])) }
+      .compose { _ => VxFuture.succeededFuture(VertxEndpointClient.make(vertx, classOf[ApiGroupsStore])) }
       .compose { (client: ApiGroupsStore) => client.getGroups() }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ExtendRulesPlugin.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/apigroup/ExtendRulesPlugin.scala
@@ -14,7 +14,9 @@ import scala.concurrent.Future
 
 class ExtendRulesPlugin extends RequestPluginVerticle[Unit] {
   override def name: PluginName = PluginName("extend")
-  override def apply(ctx: RequestCtx, conf: Unit): Future[RequestCtx] = Future.successful(ctx.abort(ApiResponse(200, Buffer.buffer(), Headers())))
+  override def apply(ctx: RequestCtx, conf: Unit): Future[RequestCtx] = Future.successful(
+    ctx.abort(ApiResponse(200, Buffer.buffer(), Headers()))
+  )
   override def validate(conf: Unit): ValidateResponse = ValidateOk
   override def confDecoder: Decoder[Unit] = Decoder.decodeUnit
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/client/SmartHttpConfsReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/client/SmartHttpConfsReaderSpec.scala
@@ -11,12 +11,12 @@ import scalaz.\/-
 class SmartHttpConfsReaderSpec extends WordSpec with MustMatchers{
   "SmartHttpConfsReader" should {
     "return empty Map if config missing" in {
-      SmartHttpConfsReader.readFromConfig(None, "") mustBe(\/-(Map()))
+      SmartHttpConfsReader.readFromConfig(None, "") mustBe \/-(Map())
     }
 
     "return failure when not all configurations json-objects" in {
       val conf = new JsonObject().put("service-a", "wrong config")
-      SmartHttpConfsReader.readFromConfig(Some(conf), "").isLeft mustBe(true)
+      SmartHttpConfsReader.readFromConfig(Some(conf), "").isLeft mustBe true
     }
 
     "return Map with configs" in {
@@ -27,7 +27,7 @@ class SmartHttpConfsReaderSpec extends WordSpec with MustMatchers{
         ServiceClientName("service-b") -> SmartHttpClientConf(new JsonObject())
       )
 
-      SmartHttpConfsReader.readFromConfig(Some(conf), "") mustBe(\/-(expected))
+      SmartHttpConfsReader.readFromConfig(Some(conf), "") mustBe \/-(expected)
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiConverterApplyPluginsTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiConverterApplyPluginsTest.scala
@@ -1,10 +1,9 @@
 package com.cloudentity.pyron.openapi
 
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
-import com.cloudentity.pyron.domain.flow.{GroupMatchCriteria, PathPattern, PathPrefix, PluginConf, ApiGroupPluginConf, PluginName, RequestCtx}
+import com.cloudentity.pyron.domain.flow._
 import com.cloudentity.pyron.domain.openapi.OpenApiRule
 import com.cloudentity.pyron.plugin.RequestPluginService
+import com.cloudentity.pyron.plugin.config.ValidateResponse
 import com.cloudentity.pyron.plugin.openapi._
 import com.cloudentity.pyron.plugin.verticle.RequestPluginVerticle
 import com.cloudentity.pyron.util.OpenApiTestUtils
@@ -12,6 +11,8 @@ import com.cloudentity.tools.vertx.conf.fixed.FixedConfVerticle
 import com.cloudentity.tools.vertx.test.ScalaVertxUnitTest
 import com.cloudentity.tools.vertx.tracing.TracingContext
 import com.cloudentity.tools.vertx.verticles.VertxDeploy
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.json.JsonObject
 import io.vertx.core.{Future => VxFuture}
@@ -26,7 +27,7 @@ class ChangeBasePathDummyPlugin extends RequestPluginVerticle[Unit] with Request
 
   override def apply(requestCtx: RequestCtx, conf: Unit): Future[RequestCtx] = Future.successful(requestCtx)
 
-  override def validate(conf: Unit) = ???
+  override def validate(conf: Unit): ValidateResponse = throw new NotImplementedError
 
   override def convertOpenApi(ctx: TracingContext, req: ConvertOpenApiRequest): VxFuture[ConvertOpenApiResponse] = {
     VxFuture.succeededFuture(ConvertedOpenApi(req.swagger.basePath("/test")))
@@ -41,7 +42,19 @@ class OpenApiConverterApplyPluginsTest extends ScalaVertxUnitTest with OpenApiTe
     val swagger = sampleSwagger("/", Map())
     val pluginConf = io.circe.Json.fromString("")
     val plugins = List(ApiGroupPluginConf(PluginName("dummy"), pluginConf, None))
-    val rules = List(OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/test"), PathPrefix(""), false, None, None, plugins, Nil, None))
+    val rules = List(OpenApiRule(
+      HttpMethod.POST,
+      sampleServiceId,
+      GroupMatchCriteria.empty,
+      PathPattern("/test"),
+      PathPrefix(""),
+      dropPathPrefix = false,
+      None,
+      None,
+      plugins,
+      Nil,
+      None
+    ))
 
     FixedConfVerticle.deploy(vertx, new JsonObject())
       .compose(_ => VertxDeploy.deploy(vertx, new ChangeBasePathDummyPlugin))

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiConverterVerticleTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiConverterVerticleTest.scala
@@ -15,30 +15,78 @@ import scala.collection.JavaConverters._
 
 
 @RunWith(classOf[JUnitRunner])
-class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with VertxSpec with FutureUtils with OpenApiTestUtils {
+class OpenApiConverterVerticleTest extends WordSpec with MustMatchers with VertxSpec with FutureUtils with OpenApiTestUtils {
 
   val converter = new OpenApiConverterVerticle()
 
   "OpenApiConverter" should {
 
     "build target service path" in {
-      val rule = OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/test"), PathPrefix(""), false, None, None, List(), Nil, None)
-      rule.targetServicePath must be ("/test")
+      val rule = OpenApiRule(
+        method = HttpMethod.GET,
+        serviceId = sampleServiceId,
+        group = GroupMatchCriteria.empty,
+        pathPattern = PathPattern("/test"),
+        pathPrefix = PathPrefix(""),
+        dropPathPrefix = false,
+        rewriteMethod = None,
+        rewritePath = None,
+        plugins = Nil,
+        tags = Nil,
+        operationId = None
+      )
+      rule.targetServicePath mustBe "/test"
     }
 
     "build target service path with path prefix" in {
-      val rule = OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/test"), PathPrefix("/service"), false, None, None, List(), Nil, None)
-      rule.targetServicePath must be ("/service/test")
+      val rule = OpenApiRule(
+        method = HttpMethod.GET,
+        serviceId = sampleServiceId,
+        group = GroupMatchCriteria.empty,
+        pathPattern = PathPattern("/test"),
+        pathPrefix = PathPrefix("/service"),
+        dropPathPrefix = false,
+        rewriteMethod = None,
+        rewritePath = None,
+        plugins = Nil,
+        tags = Nil,
+        operationId = None
+      )
+      rule.targetServicePath mustBe "/service/test"
     }
 
     "build target service path with dropped path prefix" in {
-      val rule = OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/test"), PathPrefix("/service"), true, None, None, List(), Nil, None)
-      rule.targetServicePath must be ("/test")
+      val rule = OpenApiRule(
+        method = HttpMethod.GET,
+        serviceId = sampleServiceId,
+        group = GroupMatchCriteria.empty,
+        pathPattern = PathPattern("/test"),
+        pathPrefix = PathPrefix("/service"),
+        dropPathPrefix = true,
+        rewriteMethod = None,
+        rewritePath = None,
+        plugins = Nil,
+        tags = Nil,
+        operationId = None
+      )
+      rule.targetServicePath mustBe "/test"
     }
 
     "build target service path with rewrite path" in {
-      val rule = OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/test"), PathPrefix(""), false, None, Some(RewritePath("/api/test")), List(), Nil, None)
-      rule.targetServicePath must be ("/api/test")
+      val rule = OpenApiRule(
+        method = HttpMethod.GET,
+        serviceId = sampleServiceId,
+        group = GroupMatchCriteria.empty,
+        pathPattern = PathPattern("/test"),
+        pathPrefix = PathPrefix(""),
+        dropPathPrefix = false,
+        rewriteMethod = None,
+        rewritePath = Some(RewritePath("/api/test")),
+        plugins = Nil,
+        tags = Nil,
+        operationId = None
+      )
+      rule.targetServicePath mustBe "/api/test"
     }
 
     "convert only apis defined in rules" in {
@@ -50,24 +98,60 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       val swagger = sampleSwagger(swaggerBasePath, paths)
 
       val rules = List(
-        OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, PathPattern(apiPath1), PathPrefix(swaggerBasePath), false, None, None, List(), Nil, None),
-        OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern(apiPath1), PathPrefix(swaggerBasePath), false, None, None, List(), Nil, None),
-        OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, PathPattern(apiPath2), PathPrefix(swaggerBasePath), false, None, None, List(), Nil, None)
+        OpenApiRule(
+          method = HttpMethod.GET,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern(apiPath1),
+          pathPrefix = PathPrefix(swaggerBasePath),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        ),
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern(apiPath1),
+          pathPrefix = PathPrefix(swaggerBasePath),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        ),
+        OpenApiRule(
+          method = HttpMethod.GET,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern(apiPath2),
+          pathPrefix = PathPrefix(swaggerBasePath),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        )
       )
 
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, swagger, rules, ConverterConf(None, None)))
       println(io.swagger.util.Json.pretty(result))
 
-      result.getBasePath must be ("/api")
-      result.getPaths.size() must be(2)
+      result.getBasePath mustBe "/api"
+      result.getPaths.size() mustBe 2
 
       val expectedPath1 = swaggerBasePath + apiPath1
       val path1 = result.getPath(expectedPath1)
-      path1.getOperations.size() must be (2)
+      path1.getOperations.size() mustBe 2
 
       val expectedPath2 = swaggerBasePath + apiPath2
       val path2 = result.getPath(expectedPath2)
-      path2.getOperations.size() must be (1)
+      path2.getOperations.size() mustBe 1
     }
 
     "convert api when rule with path rewrite" in {
@@ -78,17 +162,17 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
 
       val rules = List(
         OpenApiRule(
-          method         = HttpMethod.POST,
-          serviceId      = sampleServiceId,
-          group          = GroupMatchCriteria.empty,
-          pathPrefix     = PathPrefix("/apigw"),
-          pathPattern    = PathPattern("/other-users"),
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/other-users"),
+          pathPrefix = PathPrefix("/apigw"),
           dropPathPrefix = false,
-          rewriteMethod  = None,
-          rewritePath    = Some(RewritePath("/overlay/api/users")),
-          plugins        = List(),
-          tags           = Nil,
-          operationId    = None
+          rewriteMethod = None,
+          rewritePath = Some(RewritePath("/overlay/api/users")),
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
         )
       )
 
@@ -97,10 +181,10 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       println(io.swagger.util.Json.pretty(result))
 
       // then
-      result.getBasePath must be ("/api")
+      result.getBasePath mustBe "/api"
 
-      result.getPaths.size() must be(1)
-      result.getPath("/apigw/other-users") must not be (null)
+      result.getPaths.size() mustBe 1
+      result.getPath("/apigw/other-users") must not be null
     }
 
     "convert api when rule with dropped path prefix" in {
@@ -119,7 +203,7 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
           dropPathPrefix = true,
           rewriteMethod  = None,
           rewritePath    = None,
-          plugins        = List(),
+          plugins        = Nil,
           tags           = Nil,
           operationId    = None
         )
@@ -130,10 +214,10 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       println(io.swagger.util.Json.pretty(result))
 
       // then
-      result.getBasePath must be ("/api")
+      result.getBasePath mustBe "/api"
 
-      result.getPaths.size() must be(1)
-      result.getPath("/apigw/users") must not be (null)
+      result.getPaths.size() mustBe 1
+      result.getPath("/apigw/users") must not be null
     }
 
     "convert api when rule with method rewrite" in {
@@ -152,7 +236,7 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
           dropPathPrefix = false,
           rewriteMethod  = Some(RewriteMethod(HttpMethod.POST)),
           rewritePath    = None,
-          plugins        = List(),
+          plugins        = Nil,
           tags           = Nil,
           operationId    = None
         )
@@ -163,30 +247,50 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       println(io.swagger.util.Json.pretty(result))
 
       // then
-      result.getBasePath must be ("/api")
+      result.getBasePath mustBe "/api"
 
-      result.getPaths.size() must be(1)
-      result.getPath("/users") must not be (null)
-      result.getPath("/users").getPut must not be (null)
+      result.getPaths.size() mustBe 1
+      result.getPath("/users") must not be null
+      result.getPath("/users").getPut must not be null
     }
 
     "set host, basePath and scheme based on config" in {
       val getPath = sampleGetPath()
       val targetServiceSwagger = sampleSwagger("/", Map("/test" -> getPath))
       val apiGwGetPath = PathPattern("/test")
-      val rules = List(OpenApiRule(HttpMethod.GET, sampleServiceId, GroupMatchCriteria.empty, apiGwGetPath, PathPrefix(""), false, None, None, List(), Nil, None))
+      val rules = List(
+        OpenApiRule(
+          method = HttpMethod.GET,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = apiGwGetPath,
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        )
+      )
 
-      val conf = ConverterConf(Some(OpenApiDefaultsConf(Some(Host("example.com")), Some(BasePath("/api")), Some(true))), None)
+      val conf = ConverterConf(
+        defaults = Some(
+          OpenApiDefaultsConf(
+            host = Some(Host("example.com")),
+            basePath = Some(BasePath("/api")),
+            ssl = Some(true))),
+        processors = None)
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, targetServiceSwagger, rules, conf))
 
       println(io.swagger.util.Json.pretty(result))
 
-      result.getHost must be ("example.com")
-      result.getBasePath must be ("/api")
-      result.getSchemes.asScala must be (List(Scheme.HTTPS))
+      result.getHost mustBe "example.com"
+      result.getBasePath mustBe "/api"
+      result.getSchemes.asScala mustBe List(Scheme.HTTPS)
 
-      result.getPaths.size() must be (1)
-      result.getPath("/test") must be (getPath)
+      result.getPaths.size() mustBe 1
+      result.getPath("/test") mustBe getPath
     }
 
     "resolve operationId conflicts when rules proxy to the same api" in {
@@ -194,16 +298,40 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       val targetServiceSwagger = sampleSwagger("/", Map("/applications" -> postPath))
 
       val rules = List(
-        OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/applications"), PathPrefix(""), false, None, None, List(), Nil, None),
-        OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/admin/applications"), PathPrefix(""), false, None, Some(RewritePath("/applications")), List(), Nil, None)
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/applications"),
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        ),
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/admin/applications"),
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = Some(RewritePath("/applications")),
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        )
       )
 
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, targetServiceSwagger, rules, ConverterConf(None, None)))
       println(io.swagger.util.Json.pretty(result))
 
-      result.getPaths.size must be (2)
-      result.getPath("/applications").getPost.getOperationId must be ("postApplications")
-      result.getPath("/admin/applications").getPost.getOperationId must be ("postAdminApplications")
+      result.getPaths.size mustBe 2
+      result.getPath("/applications").getPost.getOperationId mustBe "postApplications"
+      result.getPath("/admin/applications").getPost.getOperationId mustBe "postAdminApplications"
     }
 
     "overwrite operationId from rule config so no conflicts when rules proxy to the same api" in {
@@ -211,37 +339,88 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       val targetServiceSwagger = sampleSwagger("/", Map("/applications" -> postPath))
 
       val rules = List(
-        OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/applications"), PathPrefix(""), false, None, None, List(), Nil, None),
-        OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/admin/applications"), PathPrefix(""), false, None, Some(RewritePath("/applications")), List(), Nil, Some("operationId"))
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/applications"),
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        ),
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/admin/applications"),
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = Some(RewritePath("/applications")),
+          plugins = Nil,
+          tags = Nil,
+          operationId = Some("operationId")
+        )
       )
 
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, targetServiceSwagger, rules, ConverterConf(None, None)))
       println(io.swagger.util.Json.pretty(result))
 
-      result.getPaths.size must be (2)
-      result.getPath("/applications").getPost.getOperationId must be ("postApi")
-      result.getPath("/admin/applications").getPost.getOperationId must be ("operationId")
+      result.getPaths.size mustBe 2
+      result.getPath("/applications").getPost.getOperationId mustBe "postApi"
+      result.getPath("/admin/applications").getPost.getOperationId mustBe "operationId"
     }
 
     "convert api when rule with drop prefix by adding prefix in generated swagger" in {
       val swagger = sampleSwagger("/", Map("/policy" -> samplePostPath()))
 
-      val rules = List(OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/policy"), PathPrefix("/authz"), true, None, None, List(), Nil, None))
+      val rules = List(
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/policy"),
+          pathPrefix = PathPrefix("/authz"),
+          dropPathPrefix = true,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        ))
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, swagger, rules, ConverterConf(None, None)))
 
-      result.getBasePath must be ("/api")
-      result.getPaths.size() must be (1)
-      result.getPath("/authz/policy") must not be (null)
+      result.getBasePath mustBe "/api"
+      result.getPaths.size() mustBe 1
+      result.getPath("/authz/policy") must not be null
     }
 
     "convert api when rules with rewrite path proxying to generic api in target service" in {
       val swagger = sampleSwagger("/", Map("/relations/{relationType}/{relationValue}" -> samplePostPath()))
 
-      val rules = List(OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/device/trust"), PathPrefix(""), false, None, Some(RewritePath("/relations/trust/trusted")), List(), Nil, None))
+      val rules = List(
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/device/trust"),
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = Some(RewritePath("/relations/trust/trusted")),
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        )
+      )
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, swagger, rules, ConverterConf(None, None)))
 
-      result.getBasePath must be ("/api")
-      result.getPaths.size() must be (1)
+      result.getBasePath mustBe "/api"
+      result.getPaths.size() mustBe 1
 
       println(io.swagger.util.Json.pretty(result))
     }
@@ -249,13 +428,27 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
     "convert api when rules with rewrite path and path params proxying to generic api in target service" in {
       val swagger = sampleSwagger("/", Map("/relations/device/{deviceUuid}/{relationType}" -> samplePostPath()))
 
-      val rules = List(OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, PathPattern("/devices/{deviceUuid}/trust"), PathPrefix(""), false, None, Some(RewritePath("/relations/device/{deviceUuid}/trust")), List(), Nil, None))
+      val rules = List(
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = PathPattern("/devices/{deviceUuid}/trust"),
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = Some(RewritePath("/relations/device/{deviceUuid}/trust")),
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        )
+      )
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, swagger, rules, ConverterConf(None, None)))
 
       println(io.swagger.util.Json.pretty(result))
 
-      result.getBasePath must be ("/api")
-      result.getPaths.size() must be (1)
+      result.getBasePath mustBe "/api"
+      result.getPaths.size() mustBe 1
 
     }
 
@@ -263,13 +456,27 @@ class OpenApiConverterVerticleOpenTest extends WordSpec with MustMatchers with V
       val targetServiceSwagger = sampleSwagger("/", Map("/application/{uuid}/capability/oauthClient" -> samplePostPath()))
       val apiGwGetPath = PathPattern("/application/{applicationId}/capability/oauthClient")
 
-      val rules = List(OpenApiRule(HttpMethod.POST, sampleServiceId, GroupMatchCriteria.empty, apiGwGetPath, PathPrefix(""), false, None, None, List(), Nil, None))
+      val rules = List(
+        OpenApiRule(
+          method = HttpMethod.POST,
+          serviceId = sampleServiceId,
+          group = GroupMatchCriteria.empty,
+          pathPattern = apiGwGetPath,
+          pathPrefix = PathPrefix(""),
+          dropPathPrefix = false,
+          rewriteMethod = None,
+          rewritePath = None,
+          plugins = Nil,
+          tags = Nil,
+          operationId = None
+        )
+      )
       val result = await(converter.convert(TracingContext.dummy(), sampleServiceId, targetServiceSwagger, rules, ConverterConf(None, None)))
 
       println(io.swagger.util.Json.pretty(result))
 
-      result.getBasePath must be ("/api")
-      result.getPaths.size() must be (1)
+      result.getBasePath mustBe "/api"
+      result.getPaths.size() mustBe 1
     }
 
   }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiProcessorsTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/OpenApiProcessorsTest.scala
@@ -4,7 +4,7 @@ import java.util
 
 import com.cloudentity.pyron.domain.flow.ServiceClientName
 import com.cloudentity.pyron.domain.openapi.{ConverterConf, DiscoverableServiceId, ProcessorsConf}
-import com.cloudentity.tools.vertx.bus.ServiceClientFactory
+import com.cloudentity.tools.vertx.bus.VertxEndpointClient
 import com.cloudentity.tools.vertx.conf.ConfVerticleDeploy
 import com.cloudentity.tools.vertx.scala.bus.ScalaServiceVerticle
 import com.cloudentity.tools.vertx.test.VertxUnitTest
@@ -19,31 +19,31 @@ import scala.collection.JavaConverters._
 
 class OpenApiProcessorsTest extends VertxUnitTest {
   @Test
-  def multiplePreAndPostProcessorsShouldByApplied(ctx: TestContext) =
+  def multiplePreAndPostProcessorsShouldByApplied(ctx: TestContext): Unit =
     processorsShouldByApplied(ctx, ProcessorsConf(Some(List("pre-a", "pre-b")), Some(List("post-a", "post-b")))) { swagger =>
       ctx.assertEquals(List("pre-a", "pre-b", "post-a", "post-b").asJava, swagger.getConsumes)
     }
 
   @Test
-  def multiplePreProcessorsShouldByApplied(ctx: TestContext) =
+  def multiplePreProcessorsShouldByApplied(ctx: TestContext): Unit =
     processorsShouldByApplied(ctx, ProcessorsConf(Some(List("pre-a", "pre-b")), None)) { swagger =>
       ctx.assertEquals(List("pre-a", "pre-b").asJava, swagger.getConsumes)
     }
 
   @Test
-  def multiplePostProcessorsShouldByApplied(ctx: TestContext) =
+  def multiplePostProcessorsShouldByApplied(ctx: TestContext): Unit =
     processorsShouldByApplied(ctx, ProcessorsConf(None, Some(List("post-a", "post-b")))) { swagger =>
       ctx.assertEquals(List("post-a", "post-b").asJava, swagger.getConsumes)
     }
 
   @Test
-  def singlePreProcessorShouldByApplied(ctx: TestContext) =
+  def singlePreProcessorShouldByApplied(ctx: TestContext): Unit =
     processorsShouldByApplied(ctx, ProcessorsConf(Some(List("pre-a")), None)) { swagger =>
       ctx.assertEquals(List("pre-a").asJava, swagger.getConsumes)
     }
 
   @Test
-  def singlePostProcessorShouldByApplied(ctx: TestContext) =
+  def singlePostProcessorShouldByApplied(ctx: TestContext): Unit =
     processorsShouldByApplied(ctx, ProcessorsConf(None, Some(List("post-a")))) { swagger =>
       ctx.assertEquals(List("post-a").asJava, swagger.getConsumes)
     }
@@ -52,7 +52,7 @@ class OpenApiProcessorsTest extends VertxUnitTest {
     ConfVerticleDeploy.deployFileConfVerticle(vertx, "src/test/resources/openapi/converter.json")
       .compose { _ => VertxDeploy.deploy(vertx, new OpenApiConverterVerticle) }
       .compose { _ =>
-        val converter = ServiceClientFactory.make(vertx.eventBus(), classOf[OpenApiConverter])
+        val converter = VertxEndpointClient.make(vertx, classOf[OpenApiConverter])
         val serviceId = DiscoverableServiceId(ServiceClientName("service-a"))
         val swagger = new Swagger()
         swagger.setPaths(new util.HashMap())

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/route/GetOpenApiRouteAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/route/GetOpenApiRouteAcceptanceTest.scala
@@ -48,7 +48,7 @@ class OpenApiMatcher(val expectedOpenApi: Swagger, val writer: ObjectWriter) ext
 }
 
 class GetOpenApiRouteAcceptanceTest extends PyronAcceptanceTest with MockUtils {
-  override def getMetaConfPath() = "src/test/resources/openapi/meta-config.json"
+  override def getMetaConfPath = "src/test/resources/openapi/meta-config.json"
 
   var targetServiceA: ClientAndServer = _
   var targetServiceB: ClientAndServer = _
@@ -69,7 +69,7 @@ class GetOpenApiRouteAcceptanceTest extends PyronAcceptanceTest with MockUtils {
     targetServiceC.close()
   }
 
-  val defaultOpenApi =
+  val defaultOpenApi: String =
     """
       |{
       |  "swagger": "2.0",

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/route/ListOpenApiRouteAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/route/ListOpenApiRouteAcceptanceTest.scala
@@ -18,9 +18,9 @@ import org.scalatest.MustMatchers
 
 
 class ListOpenApiRouteAcceptanceTest extends PyronAcceptanceTest with MustMatchers with MockUtils {
-  override def getMetaConfPath() = "src/test/resources/openapi/meta-config.json"
+  override def getMetaConfPath = "src/test/resources/openapi/meta-config.json"
 
-  val prettyPrinter = Printer.noSpaces.copy(dropNullValues = true)
+  val prettyPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
   var targetServiceA: ClientAndServer = _
   var targetServiceB: ClientAndServer = _
@@ -41,7 +41,7 @@ class ListOpenApiRouteAcceptanceTest extends PyronAcceptanceTest with MustMatche
     targetServiceC.close()
   }
 
-  val defaultOpenApi =
+  val defaultOpenApi: String =
     """
       |{
       |  "swagger": "2.0",
@@ -87,7 +87,7 @@ class ListOpenApiRouteAcceptanceTest extends PyronAcceptanceTest with MustMatche
   }
 
   class ListOpenApiMatcher(val expected: ListOpenApiResponse, val printer: Printer) extends BaseMatcher[ListOpenApiResponse] {
-    val expectedJson = expected.asJson.pretty(printer)
+    val expectedJson: String = expected.asJson.pretty(printer)
 
     override def matches(response: scala.Any): Boolean = {
       assertEquals(expectedJson, response.asInstanceOf[String])

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/RequestPluginFunctionsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/RequestPluginFunctionsSpec.scala
@@ -17,21 +17,46 @@ import scala.concurrent.{Await, Future}
 
 @RunWith(classOf[JUnitRunner])
 class RequestPluginFunctionsSpec extends WordSpec with MustMatchers with TestRequestResponseCtx {
-  val host = TargetHost("host")
-  val uri = RelativeUri.of("uri").get
+  val host: TargetHost = TargetHost("host")
+  val uri: RelativeUri = RelativeUri.of("uri").get
 
-  val original = OriginalRequest(HttpMethod.GET, UriPath(uri.path), QueryParams.empty, Headers(), None, PathParams.empty)
-  val requestGet = TargetRequest(HttpMethod.GET, StaticService(host, 100, false), uri, Headers(), None)
-  val requestPost = TargetRequest(HttpMethod.POST, StaticService(host, 100, false), uri, Headers(), None)
-  val requestDelete = TargetRequest(HttpMethod.DELETE, StaticService(host, 100, false), uri, Headers(), None)
+  val original: OriginalRequest = OriginalRequest(
+    HttpMethod.GET,
+    UriPath(uri.path),
+    QueryParams.empty,
+    Headers(),
+    None,
+    PathParams.empty
+  )
+  val requestGet: TargetRequest = TargetRequest(
+    HttpMethod.GET,
+    StaticService(host = host, port = 100, ssl = false),
+    uri,
+    Headers(),
+    None
+  )
+  val requestPost: TargetRequest = TargetRequest(
+    method = HttpMethod.POST,
+    service = StaticService(host = host, port = 100, ssl = false),
+    uri = uri,
+    headers = Headers(),
+    bodyOpt = None
+  )
+  val requestDelete: TargetRequest = TargetRequest(
+    method = HttpMethod.DELETE,
+    service = StaticService(host = host, port = 100, ssl = false),
+    uri = uri,
+    headers = Headers(),
+    bodyOpt = None
+  )
 
-  val response = ApiResponse(200, Buffer.buffer(), Headers())
+  val response: ApiResponse = ApiResponse(200, Buffer.buffer(), Headers())
 
   def requestCtx(req: TargetRequest): RequestCtx =
     emptyRequestCtx.copy(request = req)
 
   def failingPlugin(ex: Throwable): RequestPlugin =
-    (ctx: RequestCtx) => Future.failed(ex)
+    (_: RequestCtx) => Future.failed(ex)
 
   def responsePlugin(response: ApiResponse): RequestPlugin =
     (ctx: RequestCtx) => Future.successful(ctx.abort(response))
@@ -49,7 +74,7 @@ class RequestPluginFunctionsSpec extends WordSpec with MustMatchers with TestReq
         PluginFunctions.applyRequestPlugins(requestCtx(requestGet), plugins)(_ => emptyResponse)
 
       //then
-      Await.result(f, 1 second).request must be(requestDelete)
+      Await.result(f, 1 second).request mustBe requestDelete
     }
 
     "break applying request plugins when applied plugin returned ApiResponse" in {
@@ -61,7 +86,7 @@ class RequestPluginFunctionsSpec extends WordSpec with MustMatchers with TestReq
         PluginFunctions.applyRequestPlugins(requestCtx(requestGet), plugins)(_ => emptyResponse)
 
       //then
-      Await.result(f, 1 second).aborted must be(Some(emptyResponse))
+      Await.result(f, 1 second).aborted mustBe Some(emptyResponse)
     }
 
     "break applying request plugins when applied plugin returned failure" in {
@@ -74,7 +99,7 @@ class RequestPluginFunctionsSpec extends WordSpec with MustMatchers with TestReq
         PluginFunctions.applyRequestPlugins(requestCtx(requestGet), plugins)(_ => emptyResponse)
 
       //then
-      Await.result(f, 1 second).aborted must be(Some(emptyResponse))
+      Await.result(f, 1 second).aborted mustBe Some(emptyResponse)
     }
   }
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/RequestPluginFunctionsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/RequestPluginFunctionsSpec.scala
@@ -21,19 +21,19 @@ class RequestPluginFunctionsSpec extends WordSpec with MustMatchers with TestReq
   val uri: RelativeUri = RelativeUri.of("uri").get
 
   val original: OriginalRequest = OriginalRequest(
-    HttpMethod.GET,
-    UriPath(uri.path),
-    QueryParams.empty,
-    Headers(),
-    None,
-    PathParams.empty
+    method = HttpMethod.GET,
+    path = UriPath(uri.path),
+    queryParams = QueryParams.empty,
+    headers = Headers(),
+    bodyOpt = None,
+    pathParams = PathParams.empty
   )
   val requestGet: TargetRequest = TargetRequest(
-    HttpMethod.GET,
-    StaticService(host = host, port = 100, ssl = false),
-    uri,
-    Headers(),
-    None
+    method = HttpMethod.GET,
+    service = StaticService(host = host, port = 100, ssl = false),
+    uri = uri,
+    headers = Headers(),
+    bodyOpt = None
   )
   val requestPost: TargetRequest = TargetRequest(
     method = HttpMethod.POST,

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/ResponsePluginFunctionsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/ResponsePluginFunctionsSpec.scala
@@ -17,17 +17,31 @@ import scala.concurrent.{Await, Future}
 
 @RunWith(classOf[JUnitRunner])
 class ResponsePluginFunctionsSpec extends WordSpec with MustMatchers with TestRequestResponseCtx {
-  val original = OriginalRequest(HttpMethod.GET, UriPath("uri"), QueryParams.empty, Headers(), None, PathParams.empty)
-  val request = TargetRequest(HttpMethod.GET, StaticService(TargetHost("host"), 100, false), RelativeUri.of("uri").get, Headers(), None)
 
-  val response200 = ApiResponse(200, Buffer.buffer(), Headers())
-  val response300 = ApiResponse(300, Buffer.buffer(), Headers())
-  val response400 = ApiResponse(400, Buffer.buffer(), Headers())
+  val original: OriginalRequest = OriginalRequest(
+    HttpMethod.GET,
+    UriPath("uri"),
+    QueryParams.empty,
+    Headers(),
+    None,
+    PathParams.empty
+  )
+  val request: TargetRequest = TargetRequest(
+    method = HttpMethod.GET,
+    service = StaticService(host = TargetHost("host"), port = 100, ssl = false),
+    uri = RelativeUri.of("uri").get,
+    headers = Headers(),
+    bodyOpt = None
+  )
 
-  def responseCtx(resp: ApiResponse) = emptyResponseCtx.copy(response = resp)
+  val response200: ApiResponse = ApiResponse(200, Buffer.buffer(), Headers())
+  val response300: ApiResponse = ApiResponse(300, Buffer.buffer(), Headers())
+  val response400: ApiResponse = ApiResponse(400, Buffer.buffer(), Headers())
+
+  def responseCtx(resp: ApiResponse): ResponseCtx = emptyResponseCtx.copy(response = resp)
 
   def failingPlugin(ex: Throwable): ResponsePlugin =
-    (ctx: ResponseCtx) => Future.failed(ex)
+    (_: ResponseCtx) => Future.failed(ex)
 
   def increaseStatusCodePlugin(increment: Int): ResponsePlugin =
     (ctx: ResponseCtx) => Future.successful(ctx.modifyResponse(_.copy(statusCode = ctx.response.statusCode + increment)))
@@ -35,27 +49,34 @@ class ResponsePluginFunctionsSpec extends WordSpec with MustMatchers with TestRe
   "Plugins.applyResponsePlugins" should {
     "return final response when all plugins successful" in {
       //given
-      val plugins = List(increaseStatusCodePlugin(100), increaseStatusCodePlugin(100))
+      val plugins = List(
+        increaseStatusCodePlugin(100),
+        increaseStatusCodePlugin(100)
+      )
 
       //when
       val f: Future[ResponseCtx] =
         PluginFunctions.applyResponsePlugins(responseCtx(response200), plugins)(_ => emptyResponse)
 
       //then
-      Await.result(f, 1 second).response must be(response400)
+      Await.result(f, 1 second).response mustBe response400
     }
 
     "not break applying plugins when applied plugin returned failure" in {
       //given
       val ex = new Exception()
-      val plugins: List[ResponsePlugin] = List(increaseStatusCodePlugin(100), failingPlugin(ex), increaseStatusCodePlugin(100))
+      val plugins: List[ResponsePlugin] = List(
+        increaseStatusCodePlugin(100),
+        failingPlugin(ex),
+        increaseStatusCodePlugin(100)
+      )
 
       //when
       val f: Future[ResponseCtx] =
         PluginFunctions.applyResponsePlugins(responseCtx(response200), plugins)(_ => emptyResponse)
 
       //then
-      Await.result(f, 1 second).response must be(response300)
+      Await.result(f, 1 second).response mustBe response300
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/ResponsePluginFunctionsSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/ResponsePluginFunctionsSpec.scala
@@ -19,12 +19,12 @@ import scala.concurrent.{Await, Future}
 class ResponsePluginFunctionsSpec extends WordSpec with MustMatchers with TestRequestResponseCtx {
 
   val original: OriginalRequest = OriginalRequest(
-    HttpMethod.GET,
-    UriPath("uri"),
-    QueryParams.empty,
-    Headers(),
-    None,
-    PathParams.empty
+    method = HttpMethod.GET,
+    path = UriPath("uri"),
+    queryParams = QueryParams.empty,
+    headers = Headers(),
+    bodyOpt = None,
+    pathParams = PathParams.empty
   )
   val request: TargetRequest = TargetRequest(
     method = HttpMethod.GET,

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/impl/acp/AcpApiGroupsSynchronizerTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/impl/acp/AcpApiGroupsSynchronizerTest.scala
@@ -4,7 +4,7 @@ import com.cloudentity.pyron.PyronAcceptanceTest
 import com.cloudentity.pyron.apigroup.{ApiGroupConf, ApiGroupId, ApiGroupsChangeListener}
 import com.cloudentity.pyron.domain.flow.{BasePath, GroupMatchCriteria}
 import com.cloudentity.pyron.rule.RulesConfReader
-import com.cloudentity.tools.vertx.bus.ServiceClientFactory
+import com.cloudentity.tools.vertx.bus.VertxEndpointClient
 import io.vertx.core.{Future, Promise}
 import io.vertx.ext.unit.TestContext
 import org.junit.{AfterClass, BeforeClass, Test}
@@ -15,7 +15,7 @@ import org.mockserver.verify.VerificationTimes
 import AcpApiGroupsSynchronizerTest._
 
 object AcpApiGroupsSynchronizerTest {
-  var authorizer: ClientAndServer = null
+  var authorizer: ClientAndServer = _
 
   @BeforeClass
   def setup(): Unit = {
@@ -28,7 +28,7 @@ object AcpApiGroupsSynchronizerTest {
     authorizer.stop()
   }
 
-  private def mockSetApis(code: Int): Unit = {
+  def mockSetApis(code: Int): Unit = {
     authorizer
       .when(request().withPath("/apis"))
       .respond(response.withStatusCode(code))
@@ -86,7 +86,7 @@ class AcpApiGroupsSynchronizerTest extends PyronAcceptanceTest {
     val expectedBody = """{"api_groups":[{"id":"a.1","apis":[{"method":"GET","path":"/payments"}]}]}"""
 
     // when
-    ServiceClientFactory.make(vertx.eventBus(), classOf[ApiGroupsChangeListener]).apiGroupsChanged(Nil, groups)
+    VertxEndpointClient.make(vertx, classOf[ApiGroupsChangeListener]).apiGroupsChanged(Nil, groups)
 
     // then
     verify("PUT", "/apis", expectedBody, 1).onComplete(ctx.asyncAssertSuccess())

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/impl/acp/AcpAuthzPluginTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/impl/acp/AcpAuthzPluginTest.scala
@@ -1,8 +1,7 @@
 package com.cloudentity.pyron.plugin.impl.acp
 
 import com.cloudentity.pyron.PyronAcceptanceTest
-import com.cloudentity.pyron.plugin.impl.acp.AcpAuthzPluginTest.authorizer
-import org.junit.{After, Before, BeforeClass, Test}
+import org.junit.{After, Before, Test}
 import org.mockserver.integration.ClientAndServer
 import io.restassured.RestAssured.given
 import org.mockserver.model.HttpRequest.request
@@ -12,24 +11,19 @@ import org.mockserver.model.{Body, HttpRequest, JsonBody}
 import io.vertx.ext.unit.TestContext
 
 object AcpAuthzPluginTest {
-  var authorizer: ClientAndServer = null
+  var authorizer: ClientAndServer = _
 
   //@BeforeClass
   def setup(): Unit = {
     authorizer = ClientAndServer.startClientAndServer(7777)
-    mockSetApis(204)
-  }
-
-  private def mockSetApis(code: Int): Unit = {
-
   }
 }
 
 class AcpAuthzPluginTest extends PyronAcceptanceTest {
   override val getMetaConfPath = "src/test/resources/modules/plugin/acp-authz/meta-config.json"
 
-  var targetService: ClientAndServer = null
-  var authorizer: ClientAndServer = null
+  var targetService: ClientAndServer = _
+  var authorizer: ClientAndServer = _
 
   @Before
   override def setUp(ctx: TestContext): Unit = {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/impl/acp/AcpAuthzPluginTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/plugin/impl/acp/AcpAuthzPluginTest.scala
@@ -16,7 +16,10 @@ object AcpAuthzPluginTest {
   //@BeforeClass
   def setup(): Unit = {
     authorizer = ClientAndServer.startClientAndServer(7777)
+    mockSetApis(204)
   }
+  
+  private def mockSetApis(code: Int): Unit = { }
 }
 
 class AcpAuthzPluginTest extends PyronAcceptanceTest {

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/PathMatchingSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/PathMatchingSpec.scala
@@ -9,10 +9,10 @@ import org.scalatest.{MustMatchers, WordSpec}
 class PathMatchingSpec extends WordSpec with MustMatchers {
   "PathMatching.createPatternRegex" should {
     "wrap pattern in ^ and $ regex symbols" in {
-      PathMatching.createPatternRegex("/path").regex must be("^/path$")
+      PathMatching.createPatternRegex("/path").regex mustBe "^/path$"
     }
     "substitute placeholder with [^/]+ regex" in {
-      PathMatching.createPatternRegex("/path/{placeholder}/path").regex must be("^/path/(?<placeholder>[^/]+)/path$")
+      PathMatching.createPatternRegex("/path/{placeholder}/path").regex mustBe "^/path/(?<placeholder>[^/]+)/path$"
     }
   }
   "PathMatching.extractPathParamNames" should {
@@ -26,7 +26,7 @@ class PathMatchingSpec extends WordSpec with MustMatchers {
       val names = extract(path)
 
       // then
-      names.map(_.value) must be(Nil)
+      names.map(_.value) mustBe Nil
     }
 
     "extract single name" in {
@@ -37,7 +37,7 @@ class PathMatchingSpec extends WordSpec with MustMatchers {
       val names = extract(path)
 
       // then
-      names.map(_.value) must be(List("placeholder"))
+      names.map(_.value) mustBe List("placeholder")
     }
 
     "extract multiple names" in {
@@ -48,7 +48,7 @@ class PathMatchingSpec extends WordSpec with MustMatchers {
       val names = extract(path)
 
       // then
-      names.map(_.value) must be(List("placeholder1", "placeholder2"))
+      names.map(_.value) mustBe List("placeholder1", "placeholder2")
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RewritePathSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RewritePathSpec.scala
@@ -12,7 +12,14 @@ import org.scalatestplus.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class RewritePathSpec extends FlatSpec {
 
-  val originalDefault = OriginalRequest(HttpMethod.GET, UriPath("/path"), QueryParams.empty, Headers(), None, PathParams.empty)
+  val originalDefault: OriginalRequest = OriginalRequest(
+    method = HttpMethod.GET,
+    path = UriPath("/path"),
+    queryParams = QueryParams.empty,
+    headers = Headers(),
+    bodyOpt = None,
+    pathParams = PathParams.empty
+  )
 
   it should "rewrite path without params" in {
     val rewritePathConf = "/api/new/path"

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RuleMatcherSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RuleMatcherSpec.scala
@@ -15,48 +15,48 @@ class RuleMatcherSpec extends WordSpec with MustMatchers with ScalaCheckDrivenPr
 
   case class PathSuffix(value: String)
 
-  implicit val pathPrefixArb = Arbitrary(Gen.alphaNumStr.map(PathPrefix))
-  implicit val pathSuffixArb = Arbitrary(Gen.alphaNumStr.map(PathSuffix))
-  implicit val methodArb = Arbitrary(Gen.oneOf(HttpMethod.values()))
+  implicit val pathPrefixArb: Arbitrary[PathPrefix] = Arbitrary(Gen.alphaNumStr.map(PathPrefix))
+  implicit val pathSuffixArb: Arbitrary[PathSuffix] = Arbitrary(Gen.alphaNumStr.map(PathSuffix))
+  implicit val methodArb: Arbitrary[HttpMethod] = Arbitrary(Gen.oneOf(HttpMethod.values()))
 
   "RuleMatcher.makeMatch" should {
     "return Match when basePath, path, prefix and method IS matching" in {
       forAll(minSuccessful(10)) { (method: HttpMethod, prefix: PathPrefix, suffix: PathSuffix) =>
-        val criteria = EndpointMatchCriteria(method, PathMatching((s"^${prefix.value}${suffix.value}$$").r, Nil, prefix, ""))
-        makeMatch(method, "/base-path" + prefix.value + suffix.value, BasePath("/base-path"), criteria) must be(Match(PathParams(Map())))
+        val criteria = EndpointMatchCriteria(method, PathMatching(s"^${prefix.value}${suffix.value}$$".r, Nil, prefix, ""))
+        makeMatch(method, "/base-path" + prefix.value + suffix.value, BasePath("/base-path"), criteria) mustBe Match(PathParams(Map()))
       }
     }
 
     "return Match with path params" in {
       forAll(minSuccessful(10)) { (method: HttpMethod, prefix: PathPrefix, suffix: PathSuffix) =>
-        val criteria = EndpointMatchCriteria(method, PathMatching((s"^${prefix.value}${suffix.value}$$").r, Nil, prefix, ""))
-        makeMatch(method, prefix.value + suffix.value, BasePath(""), criteria) must be(Match(PathParams(Map())))
+        val criteria = EndpointMatchCriteria(method, PathMatching(s"^${prefix.value}${suffix.value}$$".r, Nil, prefix, ""))
+        makeMatch(method, prefix.value + suffix.value, BasePath(""), criteria) mustBe Match(PathParams(Map()))
       }
     }
 
     "return NoMatch when path with prefix IS NOT matching" in {
-      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching(("^/prefix/suffix$$").r, Nil, PathPrefix("/prefix"), ""))
-      makeMatch(HttpMethod.GET, "/suffix", BasePath(""), criteria) must be(NoMatch)
+      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching("^/prefix/suffix$".r, Nil, PathPrefix("/prefix"), ""))
+      makeMatch(HttpMethod.GET, "/suffix", BasePath(""), criteria) mustBe NoMatch
     }
 
     "return NoMatch when base-path IS NOT matching" in {
-      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching(("^/prefix/suffix$$").r, Nil, PathPrefix("/prefix"), ""))
-      makeMatch(HttpMethod.GET, "/other-base-path/prefix/suffix", BasePath("/base-path"), criteria) must be(NoMatch)
+      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching("^/prefix/suffix$".r, Nil, PathPrefix("/prefix"), ""))
+      makeMatch(HttpMethod.GET, "/other-base-path/prefix/suffix", BasePath("/base-path"), criteria) mustBe NoMatch
     }
 
     "return NoMatch when path wo prefix IS NOT matching" in {
-      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching(("^/suffix$$").r, Nil, PathPrefix(""), ""))
-      makeMatch(HttpMethod.GET, "/prefix/suffix", BasePath(""), criteria) must be(NoMatch)
+      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching("^/suffix$".r, Nil, PathPrefix(""), ""))
+      makeMatch(HttpMethod.GET, "/prefix/suffix", BasePath(""), criteria) mustBe NoMatch
     }
 
     "return NoMatch when path with prefix IS matching and method IS NOT matching" in {
-      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching(("^/prefix/suffix$$").r, Nil, PathPrefix("/prefix"), ""))
-      makeMatch(HttpMethod.POST, "/prefix/suffix", BasePath(""), criteria) must be(NoMatch)
+      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching("^/prefix/suffix$".r, Nil, PathPrefix("/prefix"), ""))
+      makeMatch(HttpMethod.POST, "/prefix/suffix", BasePath(""), criteria) mustBe NoMatch
     }
 
     "return NoMatch when path with prefix IS NOT matching and method IS matching" in {
-      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching(("^/prefix/suffix$$").r, Nil, PathPrefix("/prefix"), ""))
-      makeMatch(HttpMethod.GET, "/suffix", BasePath(""), criteria) must be(NoMatch)
+      val criteria = EndpointMatchCriteria(HttpMethod.GET, PathMatching("^/prefix/suffix$".r, Nil, PathPrefix("/prefix"), ""))
+      makeMatch(HttpMethod.GET, "/suffix", BasePath(""), criteria) mustBe NoMatch
     }
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RulesConfReaderSpec.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/rule/RulesConfReaderSpec.scala
@@ -12,83 +12,180 @@ import scalaz.{Failure, Success}
 
 @RunWith(classOf[JUnitRunner])
 class RulesConfReaderSpec extends WordSpec with MustMatchers {
-  val emptyRuleConf = RulesConfReader.emptyRuleRawConf
-  val emptyConf = ServiceConf(emptyRuleConf, None, None)
-  val fullRuleConfWoPlugins = RuleRawConf(Some("endpointName"), Some(TargetHost("targetHost")), Some(80), None, None, None, Some(PathPattern("pathPattern")), None, None, None, None, Some(PathPrefix("pathPrefix")), Some(HttpMethod.GET), Some(true), None, None, None, None, None, None, None)
-  val otherFullRuleConfWoPlugins = RuleRawConf(Some("endpointName2"), Some(TargetHost("targetHost2")), Some(802), None, None, None, Some(PathPattern("pathPattern2")), None, None, None, None, Some(PathPrefix("pathPrefix2")), Some(HttpMethod.POST), Some(false), None, None, None, None, None, None, None)
+  val emptyRuleConf: RuleRawConf = RulesConfReader.emptyRuleRawConf
+  val emptyConf: ServiceConf = ServiceConf(rule = emptyRuleConf, request = None, response = None)
+  val fullRuleConfWoPlugins: RuleRawConf = RuleRawConf(
+    endpointName = Some("endpointName"),
+    targetHost = Some(TargetHost("targetHost")),
+    targetPort = Some(80),
+    targetSsl = None,
+    targetService = None,
+    targetProxy = None,
+    pathPattern = Some(PathPattern("pathPattern")),
+    rewritePath = None,
+    rewriteMethod = None,
+    copyQueryOnRewrite = None,
+    preserveHostHeader = None,
+    pathPrefix = Some(PathPrefix("pathPrefix")),
+    method = Some(HttpMethod.GET),
+    dropPrefix = Some(true),
+    requestPlugins = None,
+    responsePlugins = None,
+    tags = None,
+    requestBody = None,
+    requestBodyMaxSize = None,
+    call = None,
+    ext = None
+  )
+  val otherFullRuleConfWoPlugins: RuleRawConf = RuleRawConf(
+    endpointName = Some("endpointName2"),
+    targetHost = Some(TargetHost("targetHost2")),
+    targetPort = Some(802),
+    targetSsl = None,
+    targetService = None,
+    targetProxy = None,
+    pathPattern = Some(PathPattern("pathPattern2")),
+    rewritePath = None,
+    rewriteMethod = None,
+    copyQueryOnRewrite = None,
+    preserveHostHeader = None,
+    pathPrefix = Some(PathPrefix("pathPrefix2")),
+    method = Some(HttpMethod.POST),
+    dropPrefix = Some(false),
+    requestPlugins = None,
+    responsePlugins = None,
+    tags = None,
+    requestBody = None,
+    requestBodyMaxSize = None,
+    call = None,
+    ext = None
+  )
 
-  def serviceConf(rule: RuleRawConf) = ServiceConf(rule, None, None)
-  def endpointConf(rule: RuleRawConf) = EndpointConf(rule, None, None)
+  def serviceConf(rule: RuleRawConf): ServiceConf = ServiceConf(rule = rule, request = None, response = None)
+  def endpointConf(rule: RuleRawConf): EndpointConf = EndpointConf(rule = rule, request = None, response = None)
 
   "RulesConfReader.composeRuleConf" should {
     val composeRuleConf = RulesConfReader.composeRuleConf _
 
     val targetError = "either 'targetHost' and 'targetPort' or 'targetService' or 'targetProxy' should be set"
     "return error when `targetHost` and `targetPort` and `targetService` and 'targetProxy' missing in default and endpoint conf" in {
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(targetHost = None, targetPort = None, targetService = None, targetProxy = None))) match {
-        case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List(targetError))
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(
+          targetHost = None,
+          targetPort = None,
+          targetService = None,
+          targetProxy = None
+        ))
+      ) match {
+        case Success(_) => fail
+        case Failure(fs) => fs.list.toList mustBe List(targetError)
       }
     }
 
     "return error when `targetHost` or `targetPort` and `targetService` missing in default and endpoint conf" in {
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(targetPort = None, targetService = None))) match {
-        case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List(targetError))
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(
+          targetPort = None,
+          targetService = None
+        ))
+      ) match {
+        case Success(_) => fail
+        case Failure(fs) => fs.list.toList mustBe List(targetError)
       }
 
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(targetHost = None, targetService = None))) match {
-        case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List(targetError))
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(
+          targetHost = None,
+          targetService = None
+        ))
+      ) match {
+        case Success(_) => fail
+        case Failure(fs) => fs.list.toList mustBe List(targetError)
       }
     }
 
     "return error when `targetHost` and `targetPort` and `targetService` present in conf" in {
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(targetService = Some(ServiceClientName("service-x"))))) match {
-        case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List(targetError))
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(targetService = Some(ServiceClientName("service-x"))))
+      ) match {
+        case Success(_) => fail
+        case Failure(fs) => fs.list.toList mustBe List(targetError)
       }
     }
 
     "return error when `targetHost` and `targetPort` and `targetProxy` present in conf" in {
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(targetProxy = Some(true)))) match {
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(targetProxy = Some(true)))
+      ) match {
         case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List(targetError))
+        case Failure(fs) => fs.list.toList mustBe List(targetError)
       }
     }
 
     "return error when `targetService` and `targetProxy` present in conf" in {
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(targetService = Some(ServiceClientName("service-x")), targetProxy = Some(true)))) match {
-        case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List(targetError))
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(
+          targetService = Some(ServiceClientName("service-x")),
+          targetProxy = Some(true)
+        ))
+      ) match {
+        case Success(_) => fail
+        case Failure(fs) => fs.list.toList mustBe List(targetError)
       }
     }
 
     "return error when `pathPattern` missing in default and endpoint conf" in {
-      composeRuleConf(Map(), emptyConf, endpointConf(fullRuleConfWoPlugins.copy(pathPattern = None))) match {
-        case Success(_)  => fail
-        case Failure(fs) => fs.list.toList must be(List("missing `pathPattern`"))
+      composeRuleConf(
+        Map(),
+        emptyConf,
+        endpointConf(fullRuleConfWoPlugins.copy(pathPattern = None))
+      ) match {
+        case Success(_) => fail
+        case Failure(fs) => fs.list.toList mustBe List("missing `pathPattern`")
       }
     }
 
     val fullConfRule = Rule(
       conf =
         RuleConf(
-          endpointName    = fullRuleConfWoPlugins.endpointName,
-          criteria        = EndpointMatchCriteria(fullRuleConfWoPlugins.method.get, PathMatching((s"^${fullRuleConfWoPlugins.pathPrefix.get.value}${fullRuleConfWoPlugins.pathPattern.get.value}$$").r, Nil, fullRuleConfWoPlugins.pathPrefix.get, "")),
-          target         = StaticServiceRule(fullRuleConfWoPlugins.targetHost.get, fullRuleConfWoPlugins.targetPort.get, fullRuleConfWoPlugins.targetSsl.getOrElse(false)),
-          dropPathPrefix  = fullRuleConfWoPlugins.dropPrefix.get,
-          rewritePath     = fullRuleConfWoPlugins.rewritePath,
-          rewriteMethod   = fullRuleConfWoPlugins.rewriteMethod,
+          endpointName = fullRuleConfWoPlugins.endpointName,
+          criteria = EndpointMatchCriteria(
+            fullRuleConfWoPlugins.method.get,
+            PathMatching(
+              s"^${fullRuleConfWoPlugins.pathPrefix.get.value}${fullRuleConfWoPlugins.pathPattern.get.value}$$".r,
+              Nil,
+              fullRuleConfWoPlugins.pathPrefix.get,
+              "")
+          ),
+          target = StaticServiceRule(
+            fullRuleConfWoPlugins.targetHost.get,
+            fullRuleConfWoPlugins.targetPort.get,
+            fullRuleConfWoPlugins.targetSsl.getOrElse(false)
+          ),
+          dropPathPrefix = fullRuleConfWoPlugins.dropPrefix.get,
+          rewritePath = fullRuleConfWoPlugins.rewritePath,
+          rewriteMethod = fullRuleConfWoPlugins.rewriteMethod,
           copyQueryOnRewrite = fullRuleConfWoPlugins.copyQueryOnRewrite,
           preserveHostHeader = fullRuleConfWoPlugins.preserveHostHeader,
-          tags               = fullRuleConfWoPlugins.tags.getOrElse(Nil),
-          requestBody        = fullRuleConfWoPlugins.requestBody,
+          tags = fullRuleConfWoPlugins.tags.getOrElse(Nil),
+          requestBody = fullRuleConfWoPlugins.requestBody,
           requestBodyMaxSize = fullRuleConfWoPlugins.requestBodyMaxSize,
-          call               = fullRuleConfWoPlugins.call,
-          ext                = ExtRuleConf(None)
+          call = fullRuleConfWoPlugins.call,
+          ext = ExtRuleConf(None)
         ),
-      requestPlugins  = Nil,
+      requestPlugins = Nil,
       responsePlugins = Nil
     )
 
@@ -110,8 +207,8 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
   def assertRulesEqual(r1: RuleConf, r2: RuleConf): Unit = {
     // Regex has broken equals method (because of broken java.util.regex.Pattern.equals; it checks reference equality),
     // so we assert `regex: String` value and then copy the criteria.path
-    r1.criteria.path.regex.regex must be(r2.criteria.path.regex.regex)
-    r1 must be(r2.copy(criteria = r2.criteria.copy(path = r1.criteria.path)))
+    r1.criteria.path.regex.regex mustBe r2.criteria.path.regex.regex
+    r1 mustBe r2.copy(criteria = r2.criteria.copy(path = r1.criteria.path))
   }
 
   "RulesReader.composeRuleConfs" should {
@@ -123,19 +220,37 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
           val service0MissingFields = fs.list.toList.filter(_.startsWith("Service 0"))
           val service1MissingFields = fs.list.toList.filter(_.startsWith("Service 1"))
 
-          service0MissingFields.size must be(service1MissingFields.size)
+          service0MissingFields.size mustBe service1MissingFields.size
       }
     }
   }
 
-  val preFlowRequestPluginConfs = List(ApiGroupPluginConf(PluginName("pre-req-plugin1"), Json.Null, None), ApiGroupPluginConf(PluginName("pre-req-plugin2"), Json.Null, None))
-  val postFlowRequestPluginConfs = List(ApiGroupPluginConf(PluginName("post-req-plugin1"), Json.Null, None), ApiGroupPluginConf(PluginName("post-req-plugin2"), Json.Null, None))
-  val preFlowResponsePluginConfs = List(ApiGroupPluginConf(PluginName("pre-resp-plugin1"), Json.Null, None), ApiGroupPluginConf(PluginName("pre-resp-plugin2"), Json.Null, None))
-  val postFlowResponsePluginConfs = List(ApiGroupPluginConf(PluginName("post-resp-plugin1"), Json.Null, None), ApiGroupPluginConf(PluginName("post-resp-plugin2"), Json.Null, None))
+  val preFlowRequestPluginConfs = List(
+    ApiGroupPluginConf(PluginName("pre-req-plugin1"), Json.Null, None),
+    ApiGroupPluginConf(PluginName("pre-req-plugin2"), Json.Null, None)
+  )
+  val postFlowRequestPluginConfs = List(
+    ApiGroupPluginConf(PluginName("post-req-plugin1"), Json.Null, None),
+    ApiGroupPluginConf(PluginName("post-req-plugin2"), Json.Null, None)
+  )
+  val preFlowResponsePluginConfs = List(
+    ApiGroupPluginConf(PluginName("pre-resp-plugin1"), Json.Null, None),
+    ApiGroupPluginConf(PluginName("pre-resp-plugin2"), Json.Null, None)
+  )
+  val postFlowResponsePluginConfs = List(
+    ApiGroupPluginConf(PluginName("post-resp-plugin1"), Json.Null, None),
+    ApiGroupPluginConf(PluginName("post-resp-plugin2"), Json.Null, None)
+  )
 
-  val serviceConf  = ServiceConf(emptyRuleConf,
-    request  = Some(ServiceFlowsConf(preFlow = Some(ServiceFlowConf(preFlowRequestPluginConfs.map(p => PluginConf(p.name, p.conf)))),  postFlow = Some(ServiceFlowConf(postFlowRequestPluginConfs.map(p => PluginConf(p.name, p.conf)))))),
-    response = Some(ServiceFlowsConf(preFlow = Some(ServiceFlowConf(preFlowResponsePluginConfs.map(p => PluginConf(p.name, p.conf)))), postFlow = Some(ServiceFlowConf(postFlowResponsePluginConfs.map(p => PluginConf(p.name, p.conf))))))
+  val serviceConf: ServiceConf = ServiceConf(emptyRuleConf,
+    request = Some(ServiceFlowsConf(
+      preFlow = Some(ServiceFlowConf(preFlowRequestPluginConfs.map(p => PluginConf(p.name, p.conf)))),
+      postFlow = Some(ServiceFlowConf(postFlowRequestPluginConfs.map(p => PluginConf(p.name, p.conf)))))
+    ),
+    response = Some(ServiceFlowsConf(
+      preFlow = Some(ServiceFlowConf(preFlowResponsePluginConfs.map(p => PluginConf(p.name, p.conf)))),
+      postFlow = Some(ServiceFlowConf(postFlowResponsePluginConfs.map(p => PluginConf(p.name, p.conf)))))
+    )
   )
 
   "RulesReader.composeRequestPluginsConf" should {
@@ -148,54 +263,64 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
       val conf = composeRequestPluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(RequestPluginsConf(preFlowRequestPluginConfs, Nil, postFlowRequestPluginConfs))
+      conf mustBe RequestPluginsConf(preFlowRequestPluginConfs, Nil, postFlowRequestPluginConfs)
     }
 
     "filter-out all preFlow plugins" in {
       // given
-      val endpointRequestFlows = Some(EndpointFlowsConf(preFlow = Some(EndpointFlowConf(disableAllPlugins = Some(true), None)), postFlow = None))
-      val endpointConf         = EndpointConf(emptyRuleConf, endpointRequestFlows, None)
+      val endpointRequestFlows = Some(EndpointFlowsConf(
+        preFlow = Some(EndpointFlowConf(disableAllPlugins = Some(true), None)),
+        postFlow = None
+      ))
+      val endpointConf = EndpointConf(emptyRuleConf, endpointRequestFlows, None)
 
       // when
       val conf = composeRequestPluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(RequestPluginsConf(Nil, Nil, postFlowRequestPluginConfs))
+      conf mustBe RequestPluginsConf(Nil, Nil, postFlowRequestPluginConfs)
     }
 
     "filter-out all postFlow plugins" in {
       // given
-      val endpointRequestFlows = Some(EndpointFlowsConf(postFlow = Some(EndpointFlowConf(disableAllPlugins = Some(true), None)), preFlow = None))
+      val endpointRequestFlows = Some(EndpointFlowsConf(
+        postFlow = Some(EndpointFlowConf(disableAllPlugins = Some(true), None)),
+        preFlow = None
+      ))
       val endpointConf  = EndpointConf(emptyRuleConf, endpointRequestFlows, None)
 
       // when
       val conf = composeRequestPluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(RequestPluginsConf(preFlowRequestPluginConfs, Nil, Nil))
+      conf mustBe RequestPluginsConf(preFlowRequestPluginConfs, Nil, Nil)
     }
 
     "filter-out some plugins" in {
       // given
       val endpointRequestFlows = Some(
         EndpointFlowsConf(
-          preFlow  = Some(EndpointFlowConf(disableAllPlugins = None, disablePlugins = Some(List(PluginName("pre-req-plugin1"))))),
-          postFlow = Some(EndpointFlowConf(disableAllPlugins = None, disablePlugins = Some(List(PluginName("post-req-plugin1")))))
+          preFlow = Some(EndpointFlowConf(
+            disableAllPlugins = None,
+            disablePlugins = Some(List(PluginName("pre-req-plugin1"))))
+          ),
+          postFlow = Some(EndpointFlowConf(
+            disableAllPlugins = None,
+            disablePlugins = Some(List(PluginName("post-req-plugin1"))))
+          )
         )
       )
       val endpointResponseFlows = Some(EndpointFlowsConf(preFlow = None, postFlow = None))
-      val endpointConf          = EndpointConf(emptyRuleConf, endpointRequestFlows, endpointResponseFlows)
+      val endpointConf = EndpointConf(emptyRuleConf, endpointRequestFlows, endpointResponseFlows)
 
       // when
       val conf = composeRequestPluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(
-        RequestPluginsConf(
-          preFlowRequestPluginConfs.filterNot(_.name == PluginName("pre-req-plugin1")), 
-          Nil,
-          postFlowRequestPluginConfs.filterNot(_.name == PluginName("post-req-plugin1"))
-        )
+      conf mustBe RequestPluginsConf(
+        preFlowRequestPluginConfs.filterNot(_.name == PluginName("pre-req-plugin1")),
+        Nil,
+        postFlowRequestPluginConfs.filterNot(_.name == PluginName("post-req-plugin1"))
       )
     }
   }
@@ -210,19 +335,22 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
       val conf = composeResponsePluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(ResponsePluginsConf(preFlowResponsePluginConfs, Nil, postFlowResponsePluginConfs))
+      conf mustBe ResponsePluginsConf(preFlowResponsePluginConfs, Nil, postFlowResponsePluginConfs)
     }
 
     "filter-out all preFlow plugins" in {
       // given
-      val endpointResponseFlows = Some(EndpointFlowsConf(preFlow = Some(EndpointFlowConf(disableAllPlugins = Some(true), None)), postFlow = None))
-      val endpointConf          = EndpointConf(emptyRuleConf, None, endpointResponseFlows)
+      val endpointResponseFlows = Some(EndpointFlowsConf(
+        preFlow = Some(EndpointFlowConf(disableAllPlugins = Some(true), None)),
+        postFlow = None
+      ))
+      val endpointConf = EndpointConf(emptyRuleConf, None, endpointResponseFlows)
 
       // when
       val conf = composeResponsePluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(ResponsePluginsConf(Nil, Nil, postFlowResponsePluginConfs))
+      conf mustBe ResponsePluginsConf(Nil, Nil, postFlowResponsePluginConfs)
     }
 
     "filter-out all postFlow plugins" in {
@@ -234,7 +362,7 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
       val conf = composeResponsePluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(ResponsePluginsConf(preFlowResponsePluginConfs, Nil, Nil))
+      conf mustBe ResponsePluginsConf(preFlowResponsePluginConfs, Nil, Nil)
     }
 
     "filter-out some plugins" in {
@@ -252,12 +380,10 @@ class RulesConfReaderSpec extends WordSpec with MustMatchers {
       val conf = composeResponsePluginsConf(Map(), serviceConf, endpointConf)
 
       // then
-      conf must be(
-        ResponsePluginsConf(
-          preFlowResponsePluginConfs.filterNot(_.name == PluginName("pre-resp-plugin1")),
-          Nil,
-          postFlowResponsePluginConfs.filterNot(_.name == PluginName("post-resp-plugin1"))
-        )
+      conf mustBe ResponsePluginsConf(
+        preFlowResponsePluginConfs.filterNot(_.name == PluginName("pre-resp-plugin1")),
+        Nil,
+        postFlowResponsePluginConfs.filterNot(_.name == PluginName("post-resp-plugin1"))
       )
     }
   }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/util/MockUtils.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/util/MockUtils.scala
@@ -11,7 +11,7 @@ import org.mockserver.verify.VerificationTimes
 trait MockUtils {
   def mockOnPathWithPongingBodyAndHeaders(service: ClientAndServer)(path: String, code: Int): Unit =
     service.when(request()).callback { request: HttpRequest =>
-      if (request.getPath == path)
+      if (request.getPath.getValue == path)
         response()
           .withStatusCode(code)
           .withBody(request.getBodyAsString)
@@ -21,7 +21,7 @@ trait MockUtils {
 
   def mockOnPath(service: ClientAndServer)(path: String, resp: HttpResponse): Unit =
     service.when(request().withPath(path)).callback { request: HttpRequest =>
-      if (request.getPath == path) resp
+      if (request.getPath.getValue == path) resp
       else response().withStatusCode(404)
     }
 
@@ -33,7 +33,7 @@ trait MockUtils {
           MatchType.STRICT)
       )
     ).callback { request: HttpRequest =>
-      if (request.getPath == path ) resp
+      if (request.getPath.getValue == path ) resp
       else response().withStatusCode(404)
     }
 
@@ -59,7 +59,7 @@ trait MockUtils {
       VerificationTimes.exactly(0)
     )
 
-  def mockVaultServiceResponse(vaultService: ClientAndServer)(serial: String, body: String) = {
+  def mockVaultServiceResponse(vaultService: ClientAndServer)(serial: String, body: String): Unit = {
     vaultService.when(HttpRequest.request().withMethod("GET").withPath(s"/v1/pki/cert/$serial"))
       .respond(HttpResponse.response(body).withStatusCode(200))
   }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/util/OpenApiTestUtils.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/util/OpenApiTestUtils.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
 
 trait OpenApiTestUtils extends OpenApiConverterUtils {
 
-  val sampleServiceId = StaticServiceId(TargetHost("localhost"), 9999, false)
+  val sampleServiceId: StaticServiceId = StaticServiceId(TargetHost("localhost"), 9999, ssl = false)
 
   def sampleSwagger(basePath: String, paths: Map[String, Path]): Swagger = {
     val swagger = new Swagger()
@@ -34,18 +34,42 @@ trait OpenApiTestUtils extends OpenApiConverterUtils {
 
   def multiPath(): Path = {
     val path = new Path()
-    path.setGet(new Operation().operationId("getOperation").description("get desc").response(200, new Response().description("ok")))
-    path.setPost(new Operation().operationId("postOperation").description("get desc").response(200, new Response().description("ok")))
-    path.setPut(new Operation().operationId("putOperation").description("put desc").response(200, new Response().description("ok")))
+    path.setGet(new Operation()
+      .operationId("getOperation")
+      .description("get desc")
+      .response(200, new Response().description("ok"))
+    )
+    path.setPost(new Operation()
+      .operationId("postOperation")
+      .description("get desc")
+      .response(200, new Response().description("ok"))
+    )
+    path.setPut(new Operation()
+      .operationId("putOperation")
+      .description("put desc")
+      .response(200, new Response().description("ok"))
+    )
     path
   }
 
   def sampleGetPath(): Path = {
-    getPath("get", "getApi", "get api desc", 200, new Response().description("success"))
+    getPath(
+      method = "get",
+      operationId = "getApi",
+      desc = "get api desc",
+      responseCode = 200,
+      response = new Response().description("success")
+    )
   }
 
   def samplePostPath(): Path = {
-    getPath("post", "postApi", "post api desc", 200, new Response().description("success"))
+    getPath(
+      method = "post",
+      operationId = "postApi",
+      desc = "post api desc",
+      responseCode = 200,
+      response = new Response().description("success")
+    )
   }
 
   implicit class ConvertOpenApiResponseOps(resp: ConvertOpenApiResponse) {
@@ -67,13 +91,12 @@ trait OpenApiTestUtils extends OpenApiConverterUtils {
 
   def execMatcherOnResp[T](resp: ConvertOpenApiResponse, matcher: Matcher[T], extractor: Swagger => T): Assertion = {
     inside(resp) {
-      case ConvertedOpenApi(respSwagger) => {
+      case ConvertedOpenApi(respSwagger) =>
         val res = matcher.apply(extractor.apply(respSwagger))
         if (res.matches)
           Succeeded
         else
           fail(res.failureMessage)
-      }
       case e => fail(s"Failed to convert Swagger $e")
     }
   }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/AuthnPluginSpec.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/AuthnPluginSpec.scala
@@ -24,7 +24,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
 
   implicit lazy val ec: VertxExecutionContext = VertxExecutionContext(Vertx.vertx().getOrCreateContext())
 
-  val req = emptyRequestCtx
+  val req: RequestCtx = emptyRequestCtx
 
   def authnProviderF(f: RequestCtx => Future[Option[AuthnProviderResult]]): AuthnProvider = new AuthnProvider {
     override def authenticate(req: RequestCtx, methodConf: AuthnMethodConf): Future[Option[AuthnProviderResult]] = f(req)
@@ -37,10 +37,10 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
   }
 
   def entityProviderF(f: AuthnCtx => Future[AuthnCtx]): EntityProvider =
-    (tracingContext: TracingContext, ctx: AuthnCtx) => f(ctx)
+    (_: TracingContext, ctx: AuthnCtx) => f(ctx)
 
   def entityProvider(f: AuthnCtx => AuthnCtx): EntityProvider =
-    (tracingContext: TracingContext, ctx: AuthnCtx) => Future.succeededFuture(f(ctx))
+    (_: TracingContext, ctx: AuthnCtx) => Future.succeededFuture(f(ctx))
 
   "AuthnPluginWorker" should {
 
@@ -60,7 +60,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted() mustBe(false)
+      result.isAborted mustBe false
       result.authnCtx.value must contain(("authnMethod", Json.fromString("authn-method")))
     }
 
@@ -80,7 +80,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted() mustBe(false)
+      result.isAborted mustBe false
       result.authnCtx.value must contain(("authnMethod", Json.fromString("authn-method")))
     }
 
@@ -98,8 +98,8 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(true)
-      result.aborted.get.statusCode mustBe(401)
+      result.isAborted mustBe true
+      result.aborted.get.statusCode mustBe 401
     }
 
     "return ApiResponse WHEN authn method returned ApiResponse AND no authn method returned success" in {
@@ -116,8 +116,8 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(true)
-      result.aborted.get.statusCode mustBe(400)
+      result.isAborted mustBe true
+      result.aborted.get.statusCode mustBe 400
     }
 
     "recover authentication method provider failure by abstaining from decision" in {
@@ -135,7 +135,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(false)
+      result.isAborted mustBe false
       result.authnCtx.value must contain(("authnMethod", Json.fromString("authn-method-success")))
     }
 
@@ -160,8 +160,8 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(true)
-      result.aborted.get.statusCode mustBe(500)
+      result.isAborted mustBe true
+      result.aborted.get.statusCode mustBe 500
     }
 
     "return success with entity WHEN authn success and entity provider" in {
@@ -187,7 +187,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(false)
+      result.isAborted mustBe false
       result.authnCtx.value must contain(("user", userObject.deepMerge(fullUserObject)))
     }
 
@@ -214,7 +214,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(false)
+      result.isAborted mustBe false
       result.authnCtx.value.get("ctx-key").flatMap(_.asObject).get.toMap must contain(("user", userObject.deepMerge(fullUserObject)))
     }
 
@@ -241,7 +241,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(false)
+      result.isAborted mustBe false
       result.authnCtx.value must contain(("user", userObject.deepMerge(fullUserObject)))
     }
   }
@@ -270,9 +270,9 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(true)
-      result.aborted.get.statusCode must be(403)
-      result.aborted.get.headers.getValues("header") must be(Some(List("value")))
+      result.isAborted mustBe true
+      result.aborted.get.statusCode mustBe 403
+      result.aborted.get.headers.getValues("header") mustBe Some(List("value"))
     }
 
     "modify target request even if authn provider failed" in {
@@ -295,8 +295,8 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(false)
-      result.request.headers.getValues("header") must be(Some(List("value")))
+      result.isAborted mustBe false
+      result.request.headers.getValues("header") mustBe Some(List("value"))
     }
 
     "modify target request even if authn provider succeeded" in {
@@ -316,8 +316,8 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: RequestCtx = Await.result(worker.apply(req, conf), 1 second)
 
       // then
-      result.isAborted mustBe(false)
-      result.request.headers.getValues("header") must be(Some(List("value")))
+      result.isAborted mustBe false
+      result.request.headers.getValues("header") mustBe Some(List("value"))
     }
   }
 
@@ -342,7 +342,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: ValidateResponse = worker.validate(conf)
 
       // then
-      result mustBe(ValidateOk)
+      result mustBe ValidateOk
     }
 
     "return ValidateFailure when conf without authn methods" in {
@@ -365,7 +365,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: ValidateResponse = worker.validate(conf)
 
       // then
-      result.isInstanceOf[ValidateFailure] mustBe(true)
+      result.isInstanceOf[ValidateFailure] mustBe true
     }
 
     "return ValidateFailure when conf with entities for method without entity providers" in {
@@ -381,7 +381,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: ValidateResponse = worker.validate(conf)
 
       // then
-      result.isInstanceOf[ValidateFailure] mustBe(true)
+      result.isInstanceOf[ValidateFailure] mustBe true
     }
 
     "return ValidateFailure when conf with missing authn method" in {
@@ -404,7 +404,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: ValidateResponse = worker.validate(conf)
 
       // then
-      result.isInstanceOf[ValidateFailure] mustBe(true)
+      result.isInstanceOf[ValidateFailure] mustBe true
     }
 
     "return ValidateFailure when conf with missing entity for single authn method" in {
@@ -427,7 +427,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: ValidateResponse = worker.validate(conf)
 
       // then
-      result.isInstanceOf[ValidateFailure] mustBe(true)
+      result.isInstanceOf[ValidateFailure] mustBe true
     }
 
     "return ValidateFailure when conf with missing entity for different authn methods" in {
@@ -454,7 +454,7 @@ class AuthnPluginSpec extends WordSpec with MustMatchers with TestRequestRespons
       val result: ValidateResponse = worker.validate(conf)
 
       // then
-      result.isInstanceOf[ValidateFailure] mustBe(true)
+      result.isInstanceOf[ValidateFailure] mustBe true
     }
   }
 }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/bruteforce/BruteForceIdentifierReaderSpec.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/bruteforce/BruteForceIdentifierReaderSpec.scala
@@ -11,25 +11,34 @@ import org.scalatest.{MustMatchers, WordSpec}
 class BruteForceIdentifierReaderSpec extends WordSpec with MustMatchers with TestRequestResponseCtx {
   "IdentifierReader" should {
     "read id from header" in {
-      BruteForceIdentifierReader.read(emptyRequestCtx.modifyRequest(_.withHeader("ID", "x")), DeprecatedIdentifierSource(HeaderIdentifier, "ID")) must be(Some("x"))
+      BruteForceIdentifierReader.read(
+        emptyRequestCtx.modifyRequest(_.withHeader("ID", "x")),
+        DeprecatedIdentifierSource(HeaderIdentifier, "ID")
+      ) mustBe Some("x")
     }
 
     "return None if id missing in header" in {
-      BruteForceIdentifierReader.read(emptyRequestCtx, DeprecatedIdentifierSource(HeaderIdentifier, "ID")) must be(None)
+      BruteForceIdentifierReader.read(emptyRequestCtx, DeprecatedIdentifierSource(HeaderIdentifier, "ID")) mustBe None
     }
 
     "read id from body at top level" in {
       val body = obj("id" -> fromString("x")).noSpaces
-      BruteForceIdentifierReader.read(emptyRequestCtx.modifyRequest(_.copy(bodyOpt = Some(Buffer.buffer(body)))), DeprecatedIdentifierSource(BodyIdentifier, "id")) must be(Some("x"))
+      BruteForceIdentifierReader.read(
+        emptyRequestCtx.modifyRequest(_.copy(bodyOpt = Some(Buffer.buffer(body)))),
+        DeprecatedIdentifierSource(BodyIdentifier, "id")
+      ) mustBe Some("x")
     }
 
     "read id from body at deep level" in {
       val body = obj("user" -> obj("credentials" -> obj("username" -> fromString("x")))).noSpaces
-      BruteForceIdentifierReader.read(emptyRequestCtx.modifyRequest(_.copy(bodyOpt = Some(Buffer.buffer(body)))), DeprecatedIdentifierSource(BodyIdentifier, "user.credentials.username")) must be(Some("x"))
+      BruteForceIdentifierReader.read(
+        emptyRequestCtx.modifyRequest(_.copy(bodyOpt = Some(Buffer.buffer(body)))),
+        DeprecatedIdentifierSource(BodyIdentifier, "user.credentials.username")
+      ) mustBe Some("x")
     }
 
     "return None if id missing in body" in {
-      BruteForceIdentifierReader.read(emptyRequestCtx, DeprecatedIdentifierSource(BodyIdentifier, "id")) must be(None)
+      BruteForceIdentifierReader.read(emptyRequestCtx, DeprecatedIdentifierSource(BodyIdentifier, "id")) mustBe None
     }
   }
 }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transformer/TransformRequestPluginTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])
 class TransformRequestPluginTest extends WordSpec with MustMatchers with TestRequestResponseCtx {
-  val body = new JsonObject()
+  val body: JsonObject = new JsonObject()
     .put("shallow-string", "")
     .put("shallow-object", new JsonObject())
     .put("shallow-array", new JsonArray())
@@ -38,87 +38,87 @@ class TransformRequestPluginTest extends WordSpec with MustMatchers with TestReq
 
     def emptyBody = new JsonObject()
     "set string value in empty body" in {
-      setJsonBody(Map(Path("a") -> Option(StringJsonValue("string"))))(emptyBody) must be (new JsonObject().put("a", "string"))
+      setJsonBody(Map(Path("a") -> Option(StringJsonValue("string"))))(emptyBody) mustBe new JsonObject().put("a", "string")
     }
     "set string value deep in empty body" in {
-      setJsonBody(Map(Path("a", "b") -> Option(StringJsonValue("string"))))(emptyBody) must be (new JsonObject().put("a", new JsonObject().put("b", "string")))
+      setJsonBody(Map(Path("a", "b") -> Option(StringJsonValue("string"))))(emptyBody) mustBe new JsonObject().put("a", new JsonObject().put("b", "string"))
     }
     "set json object value in empty body" in {
       val obj = new JsonObject().put("x", "y")
-      setJsonBody(Map(Path("a") -> Option(ObjectJsonValue(obj.copy()))))(emptyBody) must be (new JsonObject().put("a", obj.copy()))
+      setJsonBody(Map(Path("a") -> Option(ObjectJsonValue(obj.copy()))))(emptyBody) mustBe new JsonObject().put("a", obj.copy())
     }
     "set json array value in empty body" in {
       val arr = new JsonArray().add("x")
-      setJsonBody(Map(Path("a") -> Option(ArrayJsonValue(arr.copy()))))(emptyBody) must be (new JsonObject().put("a", arr.copy()))
+      setJsonBody(Map(Path("a") -> Option(ArrayJsonValue(arr.copy()))))(emptyBody) mustBe new JsonObject().put("a", arr.copy())
     }
     "set null value in empty body" in {
-      setJsonBody(Map(Path("a") -> Option(NullJsonValue)))(emptyBody) must be (new JsonObject().put("a", null.asInstanceOf[String]))
+      setJsonBody(Map(Path("a") -> Option(NullJsonValue)))(emptyBody) mustBe new JsonObject().put("a", null.asInstanceOf[String])
     }
 
     def shallowBody = new JsonObject().put("x", "value")
     "set string value in shallow" in {
-      setJsonBody(Map(Path("a") -> Option(StringJsonValue("string"))))(shallowBody) must be (new JsonObject().put("a", "string").put("x", "value"))
+      setJsonBody(Map(Path("a") -> Option(StringJsonValue("string"))))(shallowBody) mustBe new JsonObject().put("a", "string").put("x", "value")
     }
     "set string value deep in shallow" in {
-      setJsonBody(Map(Path("a", "b") -> Option(StringJsonValue("string"))))(shallowBody) must be (new JsonObject().put("a", new JsonObject().put("b", "string")).put("x", "value"))
+      setJsonBody(Map(Path("a", "b") -> Option(StringJsonValue("string"))))(shallowBody) mustBe new JsonObject().put("a", new JsonObject().put("b", "string")).put("x", "value")
     }
     "set json object value in shallow" in {
       val obj = new JsonObject().put("x", "y")
-      setJsonBody(Map(Path("a") -> Option(ObjectJsonValue(obj.copy()))))(shallowBody) must be (new JsonObject().put("a", obj.copy()).put("x", "value"))
+      setJsonBody(Map(Path("a") -> Option(ObjectJsonValue(obj.copy()))))(shallowBody) mustBe new JsonObject().put("a", obj.copy()).put("x", "value")
     }
     "set json array value in shallow" in {
       val arr = new JsonArray().add("x")
-      setJsonBody(Map(Path("a") -> Option(ArrayJsonValue(arr.copy()))))(shallowBody) must be (new JsonObject().put("a", arr.copy()).put("x", "value"))
+      setJsonBody(Map(Path("a") -> Option(ArrayJsonValue(arr.copy()))))(shallowBody) mustBe new JsonObject().put("a", arr.copy()).put("x", "value")
     }
     "set null value in shallow" in {
-      setJsonBody(Map(Path("a") -> Option(NullJsonValue)))(shallowBody) must be (new JsonObject().put("a", null.asInstanceOf[String]).put("x", "value"))
+      setJsonBody(Map(Path("a") -> Option(NullJsonValue)))(shallowBody) mustBe new JsonObject().put("a", null.asInstanceOf[String]).put("x", "value")
     }
 
     "overwrite with string value in shallow" in {
-      setJsonBody(Map(Path("x") -> Option(StringJsonValue("string"))))(shallowBody) must be (new JsonObject().put("x", "string"))
+      setJsonBody(Map(Path("x") -> Option(StringJsonValue("string"))))(shallowBody) mustBe new JsonObject().put("x", "string")
     }
     "overwrite with json object value in shallow" in {
       val obj = new JsonObject().put("x", "y")
-      setJsonBody(Map(Path("x") -> Option(ObjectJsonValue(obj.copy()))))(shallowBody) must be (new JsonObject().put("x", obj.copy()))
+      setJsonBody(Map(Path("x") -> Option(ObjectJsonValue(obj.copy()))))(shallowBody) mustBe new JsonObject().put("x", obj.copy())
     }
     "overwrite with json array value in shallow" in {
       val arr = new JsonArray().add("x")
-      setJsonBody(Map(Path("x") -> Option(ArrayJsonValue(arr.copy()))))(shallowBody) must be (new JsonObject().put("x", arr.copy()))
+      setJsonBody(Map(Path("x") -> Option(ArrayJsonValue(arr.copy()))))(shallowBody) mustBe new JsonObject().put("x", arr.copy())
     }
     "overwrite with null value in shallow" in {
-      setJsonBody(Map(Path("x") -> Option(NullJsonValue)))(shallowBody) must be (new JsonObject().put("x", null.asInstanceOf[String]))
+      setJsonBody(Map(Path("x") -> Option(NullJsonValue)))(shallowBody) mustBe new JsonObject().put("x", null.asInstanceOf[String])
     }
     "overwrite with null in shallow if reference missing" in {
-      setJsonBody(Map(Path("x") -> None))(shallowBody) must be (new JsonObject().put("x", null.asInstanceOf[String]))
+      setJsonBody(Map(Path("x") -> None))(shallowBody) mustBe new JsonObject().put("x", null.asInstanceOf[String])
     }
 
     def complexBody = new JsonObject().put("x", "value").put("y", new JsonObject().put("z", "value"))
     "overwrite with string value in complex body" in {
-      setJsonBody(Map(Path("y", "z") -> Option(StringJsonValue("string"))))(complexBody) must be (new JsonObject().put("x", "value").put("y", new JsonObject().put("z", "string")))
+      setJsonBody(Map(Path("y", "z") -> Option(StringJsonValue("string"))))(complexBody) mustBe new JsonObject().put("x", "value").put("y", new JsonObject().put("z", "string"))
     }
     "overwrite with json object value in complex body" in {
       val obj = new JsonObject().put("x", "y")
-      setJsonBody(Map(Path("y", "z") -> Option(ObjectJsonValue(obj.copy()))))(complexBody) must be (new JsonObject().put("x", "value").put("y", new JsonObject().put("z", obj.copy())))
+      setJsonBody(Map(Path("y", "z") -> Option(ObjectJsonValue(obj.copy()))))(complexBody) mustBe new JsonObject().put("x", "value").put("y", new JsonObject().put("z", obj.copy()))
     }
     "overwrite with json array value in complex body" in {
       val arr = new JsonArray().add("x")
-      setJsonBody(Map(Path("y", "z") -> Option(ArrayJsonValue(arr.copy()))))(complexBody) must be (new JsonObject().put("x", "value").put("y", new JsonObject().put("z", arr.copy())))
+      setJsonBody(Map(Path("y", "z") -> Option(ArrayJsonValue(arr.copy()))))(complexBody) mustBe new JsonObject().put("x", "value").put("y", new JsonObject().put("z", arr.copy()))
     }
     "overwrite with null value in complex body" in {
-      setJsonBody(Map(Path("y", "z") -> Option(NullJsonValue)))(complexBody) must be (new JsonObject().put("x", "value").put("y", new JsonObject().put("z", null.asInstanceOf[String])))
+      setJsonBody(Map(Path("y", "z") -> Option(NullJsonValue)))(complexBody) mustBe new JsonObject().put("x", "value").put("y", new JsonObject().put("z", null.asInstanceOf[String]))
     }
     "overwrite with null in complex deep if reference missing" in {
-      setJsonBody(Map(Path("y", "z") -> None))(complexBody) must be (new JsonObject().put("x", "value").put("y", new JsonObject().put("z", null.asInstanceOf[String])))
+      setJsonBody(Map(Path("y", "z") -> None))(complexBody) mustBe new JsonObject().put("x", "value").put("y", new JsonObject().put("z", null.asInstanceOf[String]))
     }
   }
 
   "TransformJsonBody.applyBodyTransformations" should {
     "return empty buffer if dropping body without set ops" in {
-      TransformJsonBody.applyBodyTransformations(ResolvedBodyOps(None, Some(true)), new JsonObject()) must be(Buffer.buffer())
+      TransformJsonBody.applyBodyTransformations(ResolvedBodyOps(None, Some(true)), new JsonObject()) mustBe Buffer.buffer()
     }
 
     "return empty buffer if dropping body with set ops" in {
-      TransformJsonBody.applyBodyTransformations(ResolvedBodyOps(Some(Map(Path("x") -> Some(StringJsonValue("a")))), Some(true)), new JsonObject()) must be(Buffer.buffer())
+      TransformJsonBody.applyBodyTransformations(ResolvedBodyOps(Some(Map(Path("x") -> Some(StringJsonValue("a")))), Some(true)), new JsonObject()) mustBe Buffer.buffer()
     }
   }
 
@@ -126,19 +126,19 @@ class TransformRequestPluginTest extends WordSpec with MustMatchers with TestReq
     val setPathParams = TransformPathParams.setPathParams _
 
     "set value for non-existing param" in {
-      setPathParams(Map("a" -> Option("string")))(PathParams(Map())) must be (PathParams(Map("a" -> "string")))
+      setPathParams(Map("a" -> Option("string")))(PathParams(Map())) mustBe PathParams(Map("a" -> "string"))
     }
 
     "set value for existing param" in {
-      setPathParams(Map("a" -> Option("string")))(PathParams(Map("a" -> "x"))) must be (PathParams(Map("a" -> "string")))
+      setPathParams(Map("a" -> Option("string")))(PathParams(Map("a" -> "x"))) mustBe PathParams(Map("a" -> "string"))
     }
 
     "set none value for non-existing param" in {
-      setPathParams(Map("a" -> None))(PathParams(Map())) must be (PathParams(Map()))
+      setPathParams(Map("a" -> None))(PathParams(Map())) mustBe PathParams(Map())
     }
 
     "set none value for existing param" in {
-      setPathParams(Map("a" -> None))(PathParams(Map("a" -> "x"))) must be (PathParams(Map()))
+      setPathParams(Map("a" -> None))(PathParams(Map("a" -> "x"))) mustBe PathParams(Map())
     }
   }
 
@@ -146,23 +146,23 @@ class TransformRequestPluginTest extends WordSpec with MustMatchers with TestReq
     val setHeaders = TransformHeaders.setHeaders _
 
     "set value for non-existing header" in {
-      setHeaders(Map("a" -> Option(List("x"))))(Headers()) must be (Headers.of("a" -> "x"))
+      setHeaders(Map("a" -> Option(List("x"))))(Headers()) mustBe Headers.of("a" -> "x")
     }
 
     "set multi-value for non-existing header" in {
-      setHeaders(Map("a" -> Option(List("x", "y"))))(Headers()) must be (Headers("a" -> List("x", "y")))
+      setHeaders(Map("a" -> Option(List("x", "y"))))(Headers()) mustBe Headers("a" -> List("x", "y"))
     }
 
     "set value for existing header" in {
-      setHeaders(Map("a" -> Option(List("x"))))(Headers.of("a" -> "y")) must be (Headers.of("a" -> "x"))
+      setHeaders(Map("a" -> Option(List("x"))))(Headers.of("a" -> "y")) mustBe Headers.of("a" -> "x")
     }
 
     "set none value for non-existing header" in {
-      setHeaders(Map("a" -> None))(Headers()) must be (Headers())
+      setHeaders(Map("a" -> None))(Headers()) mustBe Headers()
     }
 
     "set none value for existing header" in {
-      setHeaders(Map("a" -> None))(Headers.of("a" -> "x")) must be (Headers.of())
+      setHeaders(Map("a" -> None))(Headers.of("a" -> "x")) mustBe Headers.of()
     }
   }
 }

--- a/pyron-plugin/src/test/scala/com/cloudentity/pyron/plugin/util/value/ValueResolverTest.scala
+++ b/pyron-plugin/src/test/scala/com/cloudentity/pyron/plugin/util/value/ValueResolverTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{MustMatchers, WordSpec}
 
 @RunWith(classOf[JUnitRunner])
 class ValueResolverTest extends WordSpec with MustMatchers with TestRequestResponseCtx {
-  val body = new JsonObject()
+  val body: JsonObject = new JsonObject()
     .put("shallow-string", "")
     .put("shallow-object", new JsonObject())
     .put("shallow-array", new JsonArray())
@@ -32,9 +32,9 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
         .put("null", null.asInstanceOf[String])
     )
 
-  val ctxWithBody = emptyRequestCtx.modifyRequest(_.copy(bodyOpt = Some(body.toBuffer)))
+  val ctxWithBody: RequestCtx = emptyRequestCtx.modifyRequest(_.copy(bodyOpt = Some(body.toBuffer)))
 
-  val authn =
+  val authn: AuthnCtx =
     AuthnCtx(
       "shallow-string" -> Json.fromString(""),
       "shallow-object" -> Json.obj(),
@@ -56,74 +56,74 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
       )
     )
 
-  val ctxWithAuthn = emptyRequestCtx.copy(authnCtx = authn)
+  val ctxWithAuthn: RequestCtx = emptyRequestCtx.copy(authnCtx = authn)
 
-  val pathParams = PathParams(Map("a" -> "value"))
-  val ctxWithPathParams = emptyRequestCtx.modifyRequest(_.modifyPathParams(_ => pathParams))
+  val pathParams: PathParams = PathParams(Map("a" -> "value"))
+  val ctxWithPathParams: RequestCtx = emptyRequestCtx.modifyRequest(_.modifyPathParams(_ => pathParams))
 
-  val headers = Headers("a" -> List("x", "y"))
-  val ctxWithHeaders = emptyRequestCtx.modifyRequest(_.modifyHeaders(_ => headers))
+  val headers: Headers = Headers("a" -> List("x", "y"))
+  val ctxWithHeaders: RequestCtx = emptyRequestCtx.modifyRequest(_.modifyHeaders(_ => headers))
 
   // resolve from body
 
   "ValueResolver.resolveString from body" should {
-    val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString _
+    val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString
 
     "resolve shallow string" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-string"))) must be(Some(""))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-string"))) mustBe Some("")
     }
     "resolve deep string" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "string"))) must be(Some(""))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "string"))) mustBe Some("")
     }
     "resolve shallow boolean" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-boolean"))) must be(Some("false"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-boolean"))) mustBe Some("false")
     }
     "resolve deep boolean" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "boolean"))) must be(Some("false"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "boolean"))) mustBe Some("false")
     }
     "resolve shallow float" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) must be(Some("1.0"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) mustBe Some("1.0")
     }
     "resolve deep float" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "float"))) must be(Some("1.0"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "float"))) mustBe Some("1.0")
     }
     "resolve shallow int" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-int"))) must be(Some("1"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-int"))) mustBe Some("1")
     }
     "resolve deep int" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "int"))) must be(Some("1"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "int"))) mustBe Some("1")
     }
     "resolve shallow double" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) must be(Some("1.0"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) mustBe Some("1.0")
     }
     "resolve deep double" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "double"))) must be(Some("1.0"))
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "double"))) mustBe Some("1.0")
     }
 
     "fail to resolve shallow null value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-null"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-null"))) mustBe None
     }
     "fail to resolve shallow object value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-object"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-object"))) mustBe None
     }
     "fail to resolve shallow array value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-array"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("shallow-array"))) mustBe None
     }
     "fail to resolve deep null value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "null"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "null"))) mustBe None
     }
     "fail to resolve deep object value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "object"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "object"))) mustBe None
     }
     "fail to resolve deep array value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "array"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "array"))) mustBe None
     }
 
     "fail to resolve missing shallow value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("x"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("x"))) mustBe None
     }
     "fail to resolve missing deep value" in {
-      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "x"))) must be(None)
+      resolveString(ctxWithBody, Some(body), BodyRef(Path("deep", "x"))) mustBe None
     }
   }
 
@@ -131,60 +131,60 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     val resolveListOfStrings = ValueResolver.resolveListOfStrings _
 
     "resolve shallow string" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-string"))) must be(Some(List("")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-string"))) mustBe Some(List(""))
     }
     "resolve deep string" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "string"))) must be(Some(List("")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "string"))) mustBe Some(List(""))
     }
     "resolve shallow boolean" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-boolean"))) must be(Some(List("false")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-boolean"))) mustBe Some(List("false"))
     }
     "resolve deep boolean" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "boolean"))) must be(Some(List("false")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "boolean"))) mustBe Some(List("false"))
     }
     "resolve shallow float" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) must be(Some(List("1.0")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) mustBe Some(List("1.0"))
     }
     "resolve deep float" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "float"))) must be(Some(List("1.0")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "float"))) mustBe Some(List("1.0"))
     }
     "resolve shallow int" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-int"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-int"))) mustBe Some(List("1"))
     }
     "resolve deep int" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "int"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "int"))) mustBe Some(List("1"))
     }
     "resolve shallow double" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) must be(Some(List("1.0")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) mustBe Some(List("1.0"))
     }
     "resolve deep double" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "double"))) must be(Some(List("1.0")))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "double"))) mustBe Some(List("1.0"))
     }
     "resolve shallow array" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-array"))) must be(Some(List()))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-array"))) mustBe Some(List())
     }
     "resolve deep array" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "array"))) must be(Some(List()))
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "array"))) mustBe Some(List())
     }
 
     "fail to resolve shallow null value" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-null"))) must be(None)
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-null"))) mustBe None
     }
     "fail to resolve shallow object value" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-object"))) must be(None)
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("shallow-object"))) mustBe None
     }
     "fail to resolve deep null value" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "null"))) must be(None)
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "null"))) mustBe None
     }
     "fail to resolve deep object value" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "object"))) must be(None)
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "object"))) mustBe None
     }
 
     "fail to resolve missing shallow value" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("x"))) must be(None)
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("x"))) mustBe None
     }
     "fail to resolve missing deep value" in {
-      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "x"))) must be(None)
+      resolveListOfStrings(ctxWithBody, Some(body), BodyRef(Path("deep", "x"))) mustBe None
     }
   }
 
@@ -192,122 +192,122 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     val resolveJson = ValueResolver.resolveJson _
 
     "resolve shallow string" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-string"))) must be(Some(StringJsonValue("")))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-string"))) mustBe Some(StringJsonValue(""))
     }
     "resolve deep string" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "string"))) must be(Some(StringJsonValue("")))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "string"))) mustBe Some(StringJsonValue(""))
     }
 
     "resolve shallow object" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-object"))) must be(Some(ObjectJsonValue(new JsonObject())))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-object"))) mustBe Some(ObjectJsonValue(new JsonObject()))
     }
     "resolve deep object" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "object"))) must be(Some(ObjectJsonValue(new JsonObject())))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "object"))) mustBe Some(ObjectJsonValue(new JsonObject()))
     }
 
     "resolve shallow array" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-array"))) must be(Some(ArrayJsonValue(new JsonArray())))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-array"))) mustBe Some(ArrayJsonValue(new JsonArray()))
     }
     "resolve deep array" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "array"))) must be(Some(ArrayJsonValue(new JsonArray())))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "array"))) mustBe Some(ArrayJsonValue(new JsonArray()))
     }
 
     "resolve shallow boolean" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-boolean"))) must be(Some(BooleanJsonValue(false)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-boolean"))) mustBe Some(BooleanJsonValue(false))
     }
     "resolve deep boolean" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "boolean"))) must be(Some(BooleanJsonValue(false)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "boolean"))) mustBe Some(BooleanJsonValue(false))
     }
 
     "resolve shallow float" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) must be(Some(NumberJsonValue(1.0f)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-float"))) mustBe Some(NumberJsonValue(1.0f))
     }
     "resolve deep float" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "float"))) must be(Some(NumberJsonValue(1.0f)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "float"))) mustBe Some(NumberJsonValue(1.0f))
     }
 
     "resolve shallow double" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-double"))) must be(Some(NumberJsonValue(1.0d)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-double"))) mustBe Some(NumberJsonValue(1.0d))
     }
     "resolve deep double" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "double"))) must be(Some(NumberJsonValue(1.0d)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "double"))) mustBe Some(NumberJsonValue(1.0d))
     }
 
     "resolve shallow int" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-int"))) must be(Some(NumberJsonValue(1)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-int"))) mustBe Some(NumberJsonValue(1))
     }
     "resolve deep int" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "int"))) must be(Some(NumberJsonValue(1)))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "int"))) mustBe Some(NumberJsonValue(1))
     }
 
     "resolve shallow null" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-null"))) must be(Some(NullJsonValue))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("shallow-null"))) mustBe Some(NullJsonValue)
     }
     "resolve deep null" in {
-      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "null"))) must be(Some(NullJsonValue))
+      resolveJson(ctxWithBody, Some(body), BodyRef(Path("deep", "null"))) mustBe Some(NullJsonValue)
     }
   }
 
   // resolve from authn
 
   "ValueResolver.resolveString from authn" should {
-    val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString _
+    val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString
 
     "resolve shallow string" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-string"))) must be(Some(""))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-string"))) mustBe Some("")
     }
     "resolve deep string" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "string"))) must be(Some(""))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "string"))) mustBe Some("")
     }
     "resolve shallow boolean" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-boolean"))) must be(Some("false"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-boolean"))) mustBe Some("false")
     }
     "resolve deep boolean" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "boolean"))) must be(Some("false"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "boolean"))) mustBe Some("false")
     }
     "resolve shallow float" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) must be(Some("1"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) mustBe Some("1")
     }
     "resolve deep float" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "float"))) must be(Some("1"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "float"))) mustBe Some("1")
     }
     "resolve shallow int" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-int"))) must be(Some("1"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-int"))) mustBe Some("1")
     }
     "resolve deep int" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "int"))) must be(Some("1"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "int"))) mustBe Some("1")
     }
     "resolve shallow double" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) must be(Some("1"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) mustBe Some("1")
     }
     "resolve deep double" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "double"))) must be(Some("1"))
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "double"))) mustBe Some("1")
     }
 
     "fail to resolve shallow null value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-null"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-null"))) mustBe None
     }
     "fail to resolve shallow object value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-object"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-object"))) mustBe None
     }
     "fail to resolve shallow array value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-array"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("shallow-array"))) mustBe None
     }
     "fail to resolve deep null value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "null"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "null"))) mustBe None
     }
     "fail to resolve deep object value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "object"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "object"))) mustBe None
     }
     "fail to resolve deep array value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "array"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "array"))) mustBe None
     }
 
     "fail to resolve missing shallow value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("x"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("x"))) mustBe None
     }
     "fail to resolve missing deep value" in {
-      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "x"))) must be(None)
+      resolveString(ctxWithAuthn, None, AuthnRef(Path("deep", "x"))) mustBe None
     }
   }
 
@@ -315,60 +315,60 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     val resolveListOfStrings = ValueResolver.resolveListOfStrings _
 
     "resolve shallow string" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-string"))) must be(Some(List("")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-string"))) mustBe Some(List(""))
     }
     "resolve deep string" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "string"))) must be(Some(List("")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "string"))) mustBe Some(List(""))
     }
     "resolve shallow boolean" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-boolean"))) must be(Some(List("false")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-boolean"))) mustBe Some(List("false"))
     }
     "resolve deep boolean" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "boolean"))) must be(Some(List("false")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "boolean"))) mustBe Some(List("false"))
     }
     "resolve shallow float" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) mustBe Some(List("1"))
     }
     "resolve deep float" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "float"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "float"))) mustBe Some(List("1"))
     }
     "resolve shallow int" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-int"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-int"))) mustBe Some(List("1"))
     }
     "resolve deep int" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "int"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "int"))) mustBe Some(List("1"))
     }
     "resolve shallow double" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) mustBe Some(List("1"))
     }
     "resolve deep double" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "double"))) must be(Some(List("1")))
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "double"))) mustBe Some(List("1"))
     }
     "resolve shallow array" in {
-      resolveListOfStrings(ctxWithAuthn, Some(body), AuthnRef(Path("shallow-array"))) must be(Some(List()))
+      resolveListOfStrings(ctxWithAuthn, Some(body), AuthnRef(Path("shallow-array"))) mustBe Some(List())
     }
     "resolve deep array" in {
-      resolveListOfStrings(ctxWithAuthn, Some(body), AuthnRef(Path("deep", "array"))) must be(Some(List()))
+      resolveListOfStrings(ctxWithAuthn, Some(body), AuthnRef(Path("deep", "array"))) mustBe Some(List())
     }
 
     "fail to resolve shallow null value" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-null"))) must be(None)
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-null"))) mustBe None
     }
     "fail to resolve shallow object value" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-object"))) must be(None)
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("shallow-object"))) mustBe None
     }
     "fail to resolve deep null value" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "null"))) must be(None)
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "null"))) mustBe None
     }
     "fail to resolve deep object value" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "object"))) must be(None)
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "object"))) mustBe None
     }
 
     "fail to resolve missing shallow value" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("x"))) must be(None)
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("x"))) mustBe None
     }
     "fail to resolve missing deep value" in {
-      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "x"))) must be(None)
+      resolveListOfStrings(ctxWithAuthn, None, AuthnRef(Path("deep", "x"))) mustBe None
     }
   }
 
@@ -376,73 +376,73 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     val resolveJson = ValueResolver.resolveJson _
 
     "resolve shallow string" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-string"))) must be(Some(StringJsonValue("")))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-string"))) mustBe Some(StringJsonValue(""))
     }
     "resolve deep string" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "string"))) must be(Some(StringJsonValue("")))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "string"))) mustBe Some(StringJsonValue(""))
     }
 
     "resolve shallow object" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-object"))) must be(Some(ObjectJsonValue(new JsonObject())))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-object"))) mustBe Some(ObjectJsonValue(new JsonObject()))
     }
     "resolve deep object" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "object"))) must be(Some(ObjectJsonValue(new JsonObject())))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "object"))) mustBe Some(ObjectJsonValue(new JsonObject()))
     }
 
     "resolve shallow array" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-array"))) must be(Some(ArrayJsonValue(new JsonArray())))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-array"))) mustBe Some(ArrayJsonValue(new JsonArray()))
     }
     "resolve deep array" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "array"))) must be(Some(ArrayJsonValue(new JsonArray())))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "array"))) mustBe Some(ArrayJsonValue(new JsonArray()))
     }
 
     "resolve shallow boolean" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-boolean"))) must be(Some(BooleanJsonValue(false)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-boolean"))) mustBe Some(BooleanJsonValue(false))
     }
     "resolve deep boolean" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "boolean"))) must be(Some(BooleanJsonValue(false)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "boolean"))) mustBe Some(BooleanJsonValue(false))
     }
 
     "resolve shallow float" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) must be(Some(NumberJsonValue(1.0f)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-float"))) mustBe Some(NumberJsonValue(1.0f))
     }
     "resolve deep float" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "float"))) must be(Some(NumberJsonValue(1.0f)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "float"))) mustBe Some(NumberJsonValue(1.0f))
     }
 
     "resolve shallow double" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-double"))) must be(Some(NumberJsonValue(1.0d)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-double"))) mustBe Some(NumberJsonValue(1.0d))
     }
     "resolve deep double" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "double"))) must be(Some(NumberJsonValue(1.0d)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "double"))) mustBe Some(NumberJsonValue(1.0d))
     }
 
     "resolve shallow int" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-int"))) must be(Some(NumberJsonValue(1)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-int"))) mustBe Some(NumberJsonValue(1))
     }
     "resolve deep int" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "int"))) must be(Some(NumberJsonValue(1)))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "int"))) mustBe Some(NumberJsonValue(1))
     }
 
     "resolve shallow null" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-null"))) must be(Some(NullJsonValue))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("shallow-null"))) mustBe Some(NullJsonValue)
     }
     "resolve deep null" in {
-      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "null"))) must be(Some(NullJsonValue))
+      resolveJson(ctxWithAuthn, None, AuthnRef(Path("deep", "null"))) mustBe Some(NullJsonValue)
     }
   }
 
   // resolve from pathParams
 
   "ValueResolver.resolveString from pathParams" should {
-    val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString _
+    val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString
 
     "resolve existing param" in {
-      resolveString(ctxWithPathParams, None, PathParamRef("a")) must be(Some("value"))
+      resolveString(ctxWithPathParams, None, PathParamRef("a")) mustBe Some("value")
     }
 
     "fail to resolve missing param" in {
-      resolveString(ctxWithPathParams, None, PathParamRef("x")) must be(None)
+      resolveString(ctxWithPathParams, None, PathParamRef("x")) mustBe None
     }
   }
 
@@ -450,11 +450,11 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     val resolveListOfStrings = ValueResolver.resolveListOfStrings _
 
     "resolve existing param" in {
-      resolveListOfStrings(ctxWithPathParams, None, PathParamRef("a")) must be(Some(List("value")))
+      resolveListOfStrings(ctxWithPathParams, None, PathParamRef("a")) mustBe Some(List("value"))
     }
 
     "fail to resolve missing param" in {
-      resolveListOfStrings(ctxWithPathParams, None, PathParamRef("x")) must be(None)
+      resolveListOfStrings(ctxWithPathParams, None, PathParamRef("x")) mustBe None
     }
   }
 
@@ -462,28 +462,28 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     val resolveJson = ValueResolver.resolveJson _
 
     "resolve existing param" in {
-      resolveJson(ctxWithPathParams, None, PathParamRef("a")) must be(Some(StringJsonValue("value")))
+      resolveJson(ctxWithPathParams, None, PathParamRef("a")) mustBe Some(StringJsonValue("value"))
     }
 
     "fail to resolve missing param" in {
-      resolveJson(ctxWithPathParams, None, PathParamRef("x")) must be(None)
+      resolveJson(ctxWithPathParams, None, PathParamRef("x")) mustBe None
     }
 
     // resolve from headers
 
     "ValueResolver.resolveString from headers" should {
-      val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString _
+      val resolveString: (RequestCtx, Option[JsonObject], ValueOrRef) => Option[String] = ValueResolver.resolveString
 
       "resolve first value of existing header if first-value ref type" in {
-        resolveString(ctxWithHeaders, None, HeaderRef("a", FirstHeaderRefType)) must be(Some("x"))
+        resolveString(ctxWithHeaders, None, HeaderRef("a", FirstHeaderRefType)) mustBe Some("x")
       }
 
       "resolve first value of existing header if all-values ref type" in { // if we reach this case, then someone mis-configured the plugin - trying to set a list of string to attribute that expects a string (e.g. path-param)
-        resolveString(ctxWithHeaders, None, HeaderRef("a", AllHeaderRefType)) must be(Some("x"))
+        resolveString(ctxWithHeaders, None, HeaderRef("a", AllHeaderRefType)) mustBe Some("x")
       }
 
       "fail to resolve missing header" in {
-        resolveString(ctxWithHeaders, None, HeaderRef("x", FirstHeaderRefType)) must be(None)
+        resolveString(ctxWithHeaders, None, HeaderRef("x", FirstHeaderRefType)) mustBe None
       }
     }
 
@@ -491,15 +491,15 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
       val resolveListOfStrings = ValueResolver.resolveListOfStrings _
 
       "resolve first value of existing header if first-value ref type" in {
-        resolveListOfStrings(ctxWithHeaders, None, HeaderRef("a", FirstHeaderRefType)) must be(Some(List("x")))
+        resolveListOfStrings(ctxWithHeaders, None, HeaderRef("a", FirstHeaderRefType)) mustBe Some(List("x"))
       }
 
       "resolve first value of existing header if all-values ref type" in {
-        resolveListOfStrings(ctxWithHeaders, None, HeaderRef("a", AllHeaderRefType)) must be(Some(List("x", "y")))
+        resolveListOfStrings(ctxWithHeaders, None, HeaderRef("a", AllHeaderRefType)) mustBe Some(List("x", "y"))
       }
 
       "fail to resolve missing header" in {
-        resolveListOfStrings(ctxWithHeaders, None, HeaderRef("x", FirstHeaderRefType)) must be(None)
+        resolveListOfStrings(ctxWithHeaders, None, HeaderRef("x", FirstHeaderRefType)) mustBe None
       }
     }
 
@@ -507,15 +507,15 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
       val resolveJson = ValueResolver.resolveJson _
 
       "resolve first value of existing header if first-value ref type" in {
-        resolveJson(ctxWithHeaders, None, HeaderRef("a", FirstHeaderRefType)) must be(Some(StringJsonValue("x")))
+        resolveJson(ctxWithHeaders, None, HeaderRef("a", FirstHeaderRefType)) mustBe Some(StringJsonValue("x"))
       }
 
       "resolve first value of existing header if all-values ref type" in {
-        resolveJson(ctxWithHeaders, None, HeaderRef("a", AllHeaderRefType)) must be(Some(ArrayJsonValue(new JsonArray().add("x").add("y"))))
+        resolveJson(ctxWithHeaders, None, HeaderRef("a", AllHeaderRefType)) mustBe Some(ArrayJsonValue(new JsonArray().add("x").add("y")))
       }
 
       "fail to resolve missing header" in {
-        resolveJson(ctxWithHeaders, None, HeaderRef("x", FirstHeaderRefType)) must be(None)
+        resolveJson(ctxWithHeaders, None, HeaderRef("x", FirstHeaderRefType)) mustBe None
       }
     }
   }


### PR DESCRIPTION
No changes to logic, only cleanup and fix deprecation and IntelliJ test syntax warnings.
Also, split some very long lines and added explicit param names to improve test readability.
Doing this cleanup now will help spot meaningful warnings and info in the editor. There was also a couple of small typos/errors.