### PR TITLE
SCMO-9896 Enabled extraction of array elements in transform-request/response plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- Enabled extracting array elements by index in ValueResolver (used by transform-request/response plugins)
+
 ## [1.9.0] - 2021-06-11
 
 ### Breaking change

--- a/docs/plugins/transform-request.md
+++ b/docs/plugins/transform-request.md
@@ -213,6 +213,95 @@ then target request body would look like this, provided `X-Account-No` header ha
 }
 ```
 
+Elements of JSON arrays may also be referenced using the configuration syntax `[array_index]`. For example, suppose the incoming request body is:
+
+```json
+{
+  "accounts": [
+    {
+      "name": "Savings",
+      "balance": "20000"
+    },
+    {
+      "name": "Checking",
+      "balance": "1000"
+    }
+  ]
+}
+```
+
+To set a request body attribute based on the head element of the `accounts` array, the following configuration should be used:
+
+```json
+{
+  "name": "transform-request",
+  "conf": {
+    "body": {
+      "set": {
+        "primaryAccount": "$body.accounts.[0]"
+      }
+    }
+  }
+}
+```
+
+Then the target request body would be:
+
+```json
+{
+  "accounts": [
+    {
+      "name": "Savings",
+      "balance": "20000"
+    },
+    {
+      "name": "Checking",
+      "balance": "1000"
+    }
+  ],
+  "primaryAccount": {
+    "name": "Savings",
+    "balance": "20000"
+  }
+}
+```
+
+The array element can be of any type. If the array element is itself a JSON array or object, its own nested attributes may be further referenced after the initial array element reference.
+
+In the above example, if the following configuration is used instead:
+
+```json
+{
+  "name": "transform-request",
+  "conf": {
+    "body": {
+      "set": {
+        "primaryAccountName": "$body.accounts.[0].name"
+      }
+    }
+  }
+}
+```
+
+then the target request body would be:
+
+```json
+{
+  "accounts": [
+    {
+      "name": "Savings",
+      "balance": "20000"
+    },
+    {
+      "name": "Checking",
+      "balance": "1000"
+    }
+  ],
+  "primaryAccountName": "Savings"
+}
+```
+
+
 <a id="json-body-drop"></a>
 ##### Drop body
 

--- a/pyron-plugin/src/test/scala/com/cloudentity/pyron/plugin/util/value/ValueResolverTest.scala
+++ b/pyron-plugin/src/test/scala/com/cloudentity/pyron/plugin/util/value/ValueResolverTest.scala
@@ -32,6 +32,38 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
         .put("int", 1)
         .put("null", null.asInstanceOf[String])
     )
+    .put("deep-array",
+      new JsonArray()
+        .add(new JsonObject()
+          .put("string-0", "")
+          .put("object-0", new JsonObject())
+          .put("array-0", new JsonArray())
+          .put("boolean-0", false)
+          .put("float-0", 1.0f)
+          .put("double-0", 1.0d)
+          .put("int-0", 1)
+          .put("null-0", null.asInstanceOf[String])
+        )
+        .add(new JsonObject()
+          .put("string-1", "")
+          .put("object-1", new JsonObject())
+          .put("array-1", new JsonArray())
+          .put("boolean-1", false)
+          .put("float-1", 1.0f)
+          .put("double-1", 1.0d)
+          .put("int-1", 1)
+          .put("null-1", null.asInstanceOf[String])
+        )
+        .add(new JsonArray()
+          .add("deep-string-array-elt")
+        )
+        .add("string-array-elt")
+        .add(false)
+        .add(1.0f)
+        .add(1.0d)
+        .add(1)
+        .add(null.asInstanceOf[String])
+      )
 
   val conf: JsonObject = new JsonObject()
 
@@ -199,12 +231,27 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     "resolve deep string" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "string"))) mustBe Some(StringJsonValue(""))
     }
+    "resolve deep string in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "string-0"))) mustBe Some(StringJsonValue(""))
+    }
+    "resolve deep string in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "string-1"))) mustBe Some(StringJsonValue(""))
+    }
+    "resolve string leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[3]"))) mustBe Some(StringJsonValue("string-array-elt"))
+    }
 
     "resolve shallow object" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("shallow-object"))) mustBe Some(ObjectJsonValue(new JsonObject()))
     }
     "resolve deep object" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "object"))) mustBe Some(ObjectJsonValue(new JsonObject()))
+    }
+    "resolve deep object in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "object-0"))) mustBe Some(ObjectJsonValue(new JsonObject()))
+    }
+    "resolve deep object in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "object-1"))) mustBe Some(ObjectJsonValue(new JsonObject()))
     }
 
     "resolve shallow array" in {
@@ -213,12 +260,33 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     "resolve deep array" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "array"))) mustBe Some(ArrayJsonValue(new JsonArray()))
     }
+    "resolve deep array in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "array-0"))) mustBe Some(ArrayJsonValue(new JsonArray()))
+    }
+    "resolve deep array in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "array-1"))) mustBe Some(ArrayJsonValue(new JsonArray()))
+    }
+    "resolve array leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[2]"))) mustBe Some(ArrayJsonValue(new JsonArray().add("deep-string-array-elt")))
+    }
+    "resolve string leaf array elt in nested array" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[2]", "[0]"))) mustBe Some(StringJsonValue("deep-string-array-elt"))
+    }
 
     "resolve shallow boolean" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("shallow-boolean"))) mustBe Some(BooleanJsonValue(false))
     }
     "resolve deep boolean" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "boolean"))) mustBe Some(BooleanJsonValue(false))
+    }
+    "resolve deep boolean in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "boolean-0"))) mustBe Some(BooleanJsonValue(false))
+    }
+    "resolve deep boolean in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "boolean-1"))) mustBe Some(BooleanJsonValue(false))
+    }
+    "resolve boolean leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[4]"))) mustBe Some(BooleanJsonValue(false))
     }
 
     "resolve shallow float" in {
@@ -227,12 +295,30 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     "resolve deep float" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "float"))) mustBe Some(NumberJsonValue(1.0f))
     }
+    "resolve deep float in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "float-0"))) mustBe Some(NumberJsonValue(1.0f))
+    }
+    "resolve deep float in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "float-1"))) mustBe Some(NumberJsonValue(1.0f))
+    }
+    "resolve float leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[5]"))) mustBe Some(NumberJsonValue(1.0f))
+    }
 
     "resolve shallow double" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("shallow-double"))) mustBe Some(NumberJsonValue(1.0d))
     }
     "resolve deep double" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "double"))) mustBe Some(NumberJsonValue(1.0d))
+    }
+    "resolve deep double in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "double-0"))) mustBe Some(NumberJsonValue(1.0d))
+    }
+    "resolve deep double in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "double-1"))) mustBe Some(NumberJsonValue(1.0d))
+    }
+    "resolve double leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[6]"))) mustBe Some(NumberJsonValue(1.0d))
     }
 
     "resolve shallow int" in {
@@ -241,12 +327,43 @@ class ValueResolverTest extends WordSpec with MustMatchers with TestRequestRespo
     "resolve deep int" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "int"))) mustBe Some(NumberJsonValue(1))
     }
+    "resolve deep int in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "int-0"))) mustBe Some(NumberJsonValue(1))
+    }
+    "resolve deep int in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "int-1"))) mustBe Some(NumberJsonValue(1))
+    }
+    "resolve int leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[7]"))) mustBe Some(NumberJsonValue(1))
+    }
 
     "resolve shallow null" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("shallow-null"))) mustBe Some(NullJsonValue)
     }
     "resolve deep null" in {
       resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep", "null"))) mustBe Some(NullJsonValue)
+    }
+    "resolve deep null in array 0th elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[0]", "null-0"))) mustBe Some(NullJsonValue)
+    }
+    "resolve deep null in array 1st elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[1]", "null-1"))) mustBe Some(NullJsonValue)
+    }
+    "resolve null leaf array elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[8]"))) mustBe Some(NullJsonValue)
+    }
+
+    "resolve missing array leaf elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[50]"))) mustBe None
+    }
+    "resolve missing array nested elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[50]", "name"))) mustBe None
+    }
+    "resolve missing negative array leaf elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[-1]"))) mustBe None
+    }
+    "resolve missing negative array nested elt" in {
+      resolveJson(ctxWithBody, Some(body), conf, BodyRef(Path("deep-array", "[-1]", "name"))) mustBe None
     }
   }
 


### PR DESCRIPTION
Example of a JSON object with nested array:
```json
{
  "people": [
    {
      "name": "Joe",
      "age": 38
    },
    {
      "name": "Don",
      "age": 44
    }
  ]
}
```

For reference `$body.people.[0].name`, the result is `"Joe"`
For reference `$body.people.[1]`, the result is `{"name":"Don","age":44}`

If index is out-of-bounds or references a missing attribute, the return value is `None` (bubbling up as JSON `null`).

More detailed examples in `ValueResolverTest.scala`.

Tested against core QA tests in: [localstack PR](https://github.com/cloudentity/localstack/pull/248), [jenkins test](https://jenkins.cloudentity.com/job/identity/job/local-environment/job/localstack/view/change-requests/job/PR-248)