### PR TITLE
[SCMO-9920] Fix for rewriting PathParams which includes additional wrong parameter with name '-1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Enabled extracting array elements by index in ValueResolver (used by transform-request/response plugins)
 
+### Fixed
+- Rewriting PathParams include additional wrong parameter with name '-1'
+
 ## [1.9.0] - 2021-06-11
 
 ### Breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Enabled extracting array elements by index in ValueResolver (used by transform-request/response plugins)
 
 ### Fixed
-- Rewriting PathParams include additional wrong parameter with name '-1'
+- Rewriting PathParams includes additional wrong parameter with name '-1'
 
 ## [1.9.0] - 2021-06-11
 

--- a/pyron-core/src/main/scala/com/cloudentity/pyron/rule/PreparedPathRewrite.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/rule/PreparedPathRewrite.scala
@@ -87,7 +87,7 @@ object PreparedPathRewrite {
     } yield if (i > 0) {
       rewrite.paramName(i).getOrElse(s"$i") -> regexMatch.group(i)
     } else {
-      rewrite.paramName(i - 1).getOrElse(s"${i - 1}") -> regexMatch.group(rewrite.groupCount + i - 1)
+      rewrite.paramName(i + 1).getOrElse(s"${i - 1}") -> regexMatch.group(rewrite.groupCount + i - 1)
     }
     PathParams(params.toMap)
   }


### PR DESCRIPTION
Invoking api:
 `/service/params/value1`
 which matched rule : 
`/service/params/{param1}`
rewrites params to values:
`{"-1":"value1","param1":"value1"}}`

Introduced change set path params as expected:
`{"param1":"value1"}`