### PR TITLE
SCMO-9961 Added 'remove' section to transform-request/response plugins to remove specific body entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- Added `remove` section to transform-request/response plugins to remove specific body entries
+
 ## [1.10.0] - 2021-07-12
 ### Added
 - Enabled extracting array elements by index in ValueResolver (used by transform-request/response plugins)

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/TransformerConf.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/TransformerConf.scala
@@ -7,8 +7,8 @@ import io.circe.generic.semiauto.deriveDecoder
 // transformations
 sealed trait TransformOps
 
-case class BodyOps(set: Option[Map[Path, ValueOrRef]], drop: Option[Boolean]) extends TransformOps
-case class ResolvedBodyOps(set: Option[Map[Path, Option[JsonValue]]], drop: Option[Boolean])
+case class BodyOps(set: Option[Map[Path, ValueOrRef]], remove: Option[List[Path]], drop: Option[Boolean]) extends TransformOps
+case class ResolvedBodyOps(set: Option[Map[Path, Option[JsonValue]]], remove: Option[List[Path]], drop: Option[Boolean])
 
 case class PathParamOps(set: Option[Map[String, ValueOrRef]]) extends TransformOps
 case class ResolvedPathParamOps(set: Option[Map[String, Option[String]]])
@@ -33,7 +33,7 @@ case class TransformerConf(body: BodyOps,
 
 object TransformerConf {
   implicit val BodyOpsDecoder: Decoder[BodyOps] = deriveDecoder[BodyOps].emap {
-    case BodyOps(Some(_), Some(true)) => Left("Can't both drop body and set body attribute")
+    case BodyOps(Some(_), _, Some(true)) => Left("Can't both drop body and set body attribute")
     case ops => Right(ops)
   }
   implicit val PathParamOpsDecoder: Decoder[PathParamOps] = deriveDecoder
@@ -43,7 +43,7 @@ object TransformerConf {
   implicit val TransformerConfDecoder: Decoder[TransformerConf] = deriveDecoder[TransformerConfRaw].map {
     rawConf =>
       TransformerConf(
-        body = rawConf.body.getOrElse(BodyOps(None, None)),
+        body = rawConf.body.getOrElse(BodyOps(None, None, None)),
         parseJsonBody = rawConf.body.nonEmpty || jsonBodyRefExists(rawConf),
         pathParams = rawConf.pathParams.getOrElse(PathParamOps(None)),
         queryParams = rawConf.queryParams.getOrElse(QueryParamOps(None)),

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPlugin.scala
@@ -7,7 +7,7 @@ import com.cloudentity.pyron.plugin.impl.transform.TransformHeaders.transformReq
 import com.cloudentity.pyron.plugin.impl.transform.TransformJsonBody.transformReqJsonBody
 import com.cloudentity.pyron.plugin.impl.transform._
 import com.cloudentity.pyron.plugin.openapi._
-import com.cloudentity.pyron.plugin.util.value.ValueResolver
+import com.cloudentity.pyron.plugin.util.value.{Path, ValueResolver}
 import com.cloudentity.pyron.plugin.util.value.ValueResolver.resolveJson
 import com.cloudentity.pyron.plugin.verticle.RequestPluginVerticle
 import io.circe.Decoder
@@ -66,7 +66,7 @@ class TransformRequestPlugin extends RequestPluginVerticle[TransformerConf]
     verticleConf.conf.getOrElse(new JsonObject())
 
   def resolveBodyOps(ctx: RequestCtx, bodyOps: BodyOps, jsonBodyOpt: Option[JsonObject]): ResolvedBodyOps =
-    ResolvedBodyOps(bodyOps.set.map(_.mapValues(resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.drop)
+    ResolvedBodyOps(bodyOps.set.map(_.mapValues(resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.remove, bodyOps.drop)
 
   def resolvePathParamOps(ctx: RequestCtx, pathParamOps: PathParamOps, jsonBodyOpt: Option[JsonObject]): ResolvedPathParamOps =
     ResolvedPathParamOps(pathParamOps.set.map(_.mapValues(ValueResolver.resolveString(ctx, jsonBodyOpt, confValues(), _))))

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/response/TransformResponsePlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/response/TransformResponsePlugin.scala
@@ -5,7 +5,7 @@ import com.cloudentity.pyron.plugin.config.{ValidateOk, ValidateResponse}
 import com.cloudentity.pyron.plugin.impl.transform.TransformHeaders.transformResHeaders
 import com.cloudentity.pyron.plugin.impl.transform.TransformJsonBody.{transformReqJsonBody, transformResJsonBody}
 import com.cloudentity.pyron.plugin.impl.transform._
-import com.cloudentity.pyron.plugin.util.value.ValueResolver
+import com.cloudentity.pyron.plugin.util.value.{Path, ValueResolver}
 import com.cloudentity.pyron.plugin.verticle.ResponsePluginVerticle
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
@@ -60,7 +60,7 @@ class TransformResponsePlugin  extends ResponsePluginVerticle[TransformerConf] {
     verticleConf.conf.getOrElse(new JsonObject())
 
   def resolveBodyOps(ctx: ResponseCtx, bodyOps: BodyOps, jsonBodyOpt: Option[JsonObject]): ResolvedBodyOps =
-    ResolvedBodyOps(bodyOps.set.map(_.mapValues(ValueResolver.resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.drop)
+    ResolvedBodyOps(bodyOps.set.map(_.mapValues(ValueResolver.resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.remove, bodyOps.drop)
 
   def resolveHeaderOps(ctx: ResponseCtx, headerOps: HeaderOps, jsonBodyOpt: Option[JsonObject]): ResolvedHeaderOps =
     ResolvedHeaderOps(headerOps.set.map(_.mapValues(ValueResolver.resolveListOfStrings(ctx, jsonBodyOpt, confValues(), _))))

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/TransformJsonBodyTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/TransformJsonBodyTest.scala
@@ -18,114 +18,194 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
 
     "set string value in empty body" in {
       val valAtPath = Map(Path("a") -> Option(StringJsonValue("string")))
-      setJsonBody(valAtPath)(emptyBody) mustBe emptyBody.put("a", "string")
+      setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", "string")
     }
     "set string value deep in empty body" in {
       val valAtPath = Map(Path("a", "b") -> Option(StringJsonValue("string")))
-      setJsonBody(valAtPath)(emptyBody) mustBe emptyBody.put("a", emptyBody.put("b", "string"))
+      setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", emptyBody.put("b", "string"))
     }
     "set json object value in empty body" in {
       val obj = new JsonObject().put("x", "y")
       val valAtPath = Map(Path("a") -> Option(ObjectJsonValue(obj.copy())))
-      setJsonBody(valAtPath)(emptyBody) mustBe emptyBody.put("a", obj.copy())
+      setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", obj.copy())
     }
     "set json array value in empty body" in {
       val arr = new JsonArray().add("x")
       val valAtPath = Map(Path("a") -> Option(ArrayJsonValue(arr.copy())))
-      setJsonBody(valAtPath)(emptyBody) mustBe emptyBody.put("a", arr.copy())
+      setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", arr.copy())
     }
     "set null value in empty body" in {
       val valAtPath = Map(Path("a") -> Option(NullJsonValue))
-      setJsonBody(valAtPath)(emptyBody) mustBe emptyBody.put("a", null.asInstanceOf[String])
+      setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", null.asInstanceOf[String])
     }
 
     def shallowBody = new JsonObject().put("x", "value")
 
     "set string value in shallow" in {
       val valAtPath = Map(Path("a") -> Option(StringJsonValue("string")))
-      setJsonBody(valAtPath)(shallowBody) mustBe shallowBody.put("a", "string")
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", "string")
     }
     "set string value deep in shallow" in {
       val valAtPath = Map(Path("a", "b") -> Option(StringJsonValue("string")))
-      setJsonBody(valAtPath)(shallowBody) mustBe shallowBody.put("a", new JsonObject().put("b", "string"))
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", new JsonObject().put("b", "string"))
     }
     "set json object value in shallow" in {
       val obj = new JsonObject().put("x", "y")
       val valAtPath = Map(Path("a") -> Option(ObjectJsonValue(obj.copy())))
-      setJsonBody(valAtPath)(shallowBody) mustBe shallowBody.put("a", obj.copy())
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", obj.copy())
     }
     "set json array value in shallow" in {
       val arr = new JsonArray().add("x")
       val valAtPath = Map(Path("a") -> Option(ArrayJsonValue(arr.copy())))
-      setJsonBody(valAtPath)(shallowBody) mustBe shallowBody.put("a", arr.copy())
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", arr.copy())
     }
     "set null value in shallow" in {
       val valAtPath = Map(Path("a") -> Option(NullJsonValue))
-      setJsonBody(valAtPath)(shallowBody) mustBe shallowBody.put("a", null.asInstanceOf[String])
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", null.asInstanceOf[String])
     }
 
     "overwrite with string value in shallow" in {
       val valAtPath = Map(Path("x") -> Option(StringJsonValue("string")))
-      setJsonBody(valAtPath)(shallowBody) mustBe emptyBody.put("x", "string")
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", "string")
     }
     "overwrite with json object value in shallow" in {
       val obj = new JsonObject().put("u", "v")
       val valAtPath = Map(Path("x") -> Option(ObjectJsonValue(obj.copy())))
-      setJsonBody(valAtPath)(shallowBody) mustBe emptyBody.put("x", obj.copy())
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", obj.copy())
     }
     "overwrite with json array value in shallow" in {
       val arr = new JsonArray().add("x")
       val valAtPath = Map(Path("x") -> Option(ArrayJsonValue(arr.copy())))
-      setJsonBody(valAtPath)(shallowBody) mustBe emptyBody.put("x", arr.copy())
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", arr.copy())
     }
     "overwrite with null value in shallow" in {
       val valAtPath = Map(Path("x") -> Option(NullJsonValue))
-      setJsonBody(valAtPath)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
     }
     "overwrite with null in shallow if reference missing" in {
       val valAtPath = Map(Path("x") -> None)
-      setJsonBody(valAtPath)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
+    }
+
+    "remove existing value" in {
+      val removePath = List(Path("x"))
+      setJsonBody(Map.empty, removePath)(shallowBody) mustBe emptyBody
+    }
+
+    "remove existing value while adding new" in {
+      val valAtPath = Map(Path("y") -> Option(StringJsonValue("string")))
+      val removePath = List(Path("x"))
+      setJsonBody(valAtPath, removePath)(shallowBody) mustBe emptyBody.put("y", "string")
+    }
+
+    "remove existing value while replacing" in {
+      val valAtPath = Map(Path("x") -> Option(StringJsonValue("string")))
+      val removePath = List(Path("x"))
+      setJsonBody(valAtPath, removePath)(shallowBody) mustBe emptyBody
     }
 
     def complexBody = new JsonObject(""" { "x": "value", "y" : { "z": "value" } } """)
 
     "overwrite with string value in complex body" in {
       val valAtPath = Map(Path("y", "z") -> Option(StringJsonValue("string")))
-      setJsonBody(valAtPath)(complexBody) mustBe
+      setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": "string" } } """)
     }
     "overwrite with json object value in complex body" in {
       val obj = new JsonObject().put("u", "v")
       val valAtPath = Map(Path("y", "z") -> Option(ObjectJsonValue(obj)))
-      setJsonBody(valAtPath)(complexBody) mustBe
+      setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": { "u" : "v" } } } """)
     }
     "overwrite with json array value in complex body" in {
       val arr = new JsonArray().add("u")
       val valAtPath = Map(Path("y", "z") -> Option(ArrayJsonValue(arr)))
-      setJsonBody(valAtPath)(complexBody) mustBe
+      setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": [ "u" ] } } """)
     }
     "overwrite with null value in complex body" in {
       val valAtPath = Map(Path("y", "z") -> Option(NullJsonValue))
-      setJsonBody(valAtPath)(complexBody) mustBe
+      setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": null } } """)
     }
     "overwrite with null in complex deep if reference missing" in {
       val valAtPath = Map(Path("y", "z") -> None)
-      setJsonBody(valAtPath)(complexBody) mustBe
+      setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": null } } """)
+    }
+
+    "remove value in complex body" in {
+      val removePath = List(Path("y", "z"))
+      setJsonBody(Map.empty, removePath)(complexBody) mustBe
+        new JsonObject(""" { "x": "value", "y" : {} } """)
+    }
+
+    "remove nested object in complex body" in {
+      val removePath = List(Path("y"))
+      setJsonBody(Map.empty, removePath)(complexBody) mustBe
+        new JsonObject(""" { "x": "value" } """)
+    }
+
+    "remove multiple elements in complex body" in {
+      val removePath = List(Path("x"), Path("y", "z"))
+      setJsonBody(Map.empty, removePath)(complexBody) mustBe
+        new JsonObject(""" { "y": {} } """)
+    }
+
+    def shallowBodyWithArray = new JsonObject(""" { "x": ["value0", "value1", "value2"] } """)
+
+    "remove array from shallow body" in {
+      val removePath = List(Path("x"))
+      setJsonBody(Map.empty, removePath)(shallowBodyWithArray) mustBe emptyBody
+    }
+
+    "remove array element from shallow body" in {
+      val removePath = List(Path("x", "[1]"))
+      setJsonBody(Map.empty, removePath)(shallowBodyWithArray) mustBe emptyBody.put("x", new JsonArray("""["value0", "value2"]"""))
+    }
+
+    "do nothing if removing negative array element" in {
+      val removePath = List(Path("x", "[-1]"))
+      setJsonBody(Map.empty, removePath)(shallowBodyWithArray) mustBe shallowBodyWithArray
+    }
+
+    "do nothing if removing out-of-bounds array element" in {
+      val removePath = List(Path("x", "[4]"))
+      setJsonBody(Map.empty, removePath)(shallowBodyWithArray) mustBe shallowBodyWithArray
+    }
+
+    "do nothing if removing nonexistent nested array element" in {
+      val removePath = List(Path("x", "[1]", "foo"))
+      setJsonBody(Map.empty, removePath)(shallowBodyWithArray) mustBe shallowBodyWithArray
+    }
+
+    "do nothing if dereferencing an array without index notation" in {
+      val removePath = List(Path("x", "y"))
+      setJsonBody(Map.empty, removePath)(shallowBodyWithArray) mustBe shallowBodyWithArray
+    }
+
+    def complexBodyWithArray = new JsonObject(""" {"x":["value0","value1",{"x2":"value2","x3":["value3","value4"]}],"y":{"y1":["value1"]}} """)
+
+    "remove array from complex body" in {
+      val removePath = List(Path("x"), Path("y"))
+      setJsonBody(Map.empty, removePath)(complexBodyWithArray) mustBe emptyBody
+    }
+
+    "remove deeply nested array elements" in {
+      val removePath = List(Path("x", "[2]", "x3", "[0]"), Path("y", "y1", "[0]"))
+      setJsonBody(Map.empty, removePath)(complexBodyWithArray) mustBe
+        new JsonObject(""" {"x":["value0","value1",{"x2":"value2","x3":["value4"]}],"y":{"y1":[]}} """)
     }
   }
 
   "TransformJsonBody.applyBodyTransformations" should {
     "return empty buffer if dropping body without set ops" in {
-      val bodyOps = ResolvedBodyOps(set = None, drop = Some(true))
+      val bodyOps = ResolvedBodyOps(set = None, remove = None, drop = Some(true))
       applyBodyTransformations(bodyOps, new JsonObject().put("x", "y")) mustBe Buffer.buffer()
     }
 
     "return empty buffer if dropping body with set ops" in {
-      val bodyOps = ResolvedBodyOps(set = Some(Map(Path("x") -> Some(StringJsonValue("a")))), drop = Some(true))
+      val bodyOps = ResolvedBodyOps(set = Some(Map(Path("x") -> Some(StringJsonValue("a")))), remove = None, drop = Some(true))
       applyBodyTransformations(bodyOps, new JsonObject().put("x", "y")) mustBe Buffer.buffer()
     }
   }

--- a/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/domain.scala
+++ b/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/domain.scala
@@ -80,7 +80,11 @@ object ValueOrRef {
 
 case class Path(value: List[String])
 object Path {
-  implicit val PathDecoder: KeyDecoder[Path] = key => Some(Path(key.split('.').toList))
+  implicit val PathKeyDecoder: KeyDecoder[Path] = key => Some(Path(key.split('.').toList))
+
+  implicit val PathDecoder: Decoder[Path] = Decoder.decodeString.emap(key =>
+    Right(Path(key.split('.').toList))
+  )
 
   def apply(xs: String*): Path = Path(xs.toList)
 }


### PR DESCRIPTION
## [Jira Task](https://cloudentity.atlassian.net/browse/SCMO-9961)

## Description
Enabled `remove` block for transform-request/response plugins (body only). This allows removing a specific entry from the JSON body. 

## Motivation and Context
See JIRA ticket for explanation.

## Types of changes
* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
* [x] Tests (extending the test suite)
* [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?
* Unit tests
* Utilization in localstack msaas-evluma

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x]  I have added tests to cover my changes
* [X] All new and existing tests passed
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
