### PR TITLE
[SCMO-9952] Fixed generate open API with path params taken from rule definition

### DIFF
--- a/pyron-core/src/main/scala/com/cloudentity/pyron/openapi/OpenApiUtils.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/openapi/OpenApiUtils.scala
@@ -39,9 +39,11 @@ trait OpenApiConverterUtils {
   def onlyPathParamsDefinedInRulePath(rulePath: String, pp: PathParams, operation: Operation): Option[Operation] = {
     val paramsInRulePath: Map[String, String] = pp.value.filter(param => isPathParam(rulePath, param._2))
     val woHardcodedPathParams = operation.getParameters().asScala.filter(p => !p.getIn.equals("path") || paramsInRulePath.keySet.contains(p.getName)).asJava
-    operation.setParameters(woHardcodedPathParams)
 
-    Option(operation)
+    val operationCopy = deepCopyOperation(operation)
+    operationCopy.setParameters(woHardcodedPathParams)
+
+    Option(operationCopy)
   }
 
   def adjustPathParams(operation: Operation, swagger: Swagger, apiGwPath: String): Operation = {


### PR DESCRIPTION
Fixed generating open API by  basing on rule definition from api-gateway. 

Issue description:
In some rules, path params were hardcoded(in relation to original path definition from service API), but still included in generated swagger it caused semantic errors.


 