### PR TITLE
SCMO-9967 Added nullIfAbsent flag to transform body plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - Added `remove` section to transform-request/response plugins to remove specific body entries
+- Added `nullIfAbsent` flag (true by default) to transform-request/response plugins to allow disabling setting explicit null if mapped value not found
 
 ### Changed
 - Move owasp profile location to limit bom to pyron app (from pyron root), change generation to single BOM and bump plugin version

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/TransformerConf.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/TransformerConf.scala
@@ -7,8 +7,8 @@ import io.circe.generic.semiauto.deriveDecoder
 // transformations
 sealed trait TransformOps
 
-case class BodyOps(set: Option[Map[Path, ValueOrRef]], remove: Option[List[Path]], drop: Option[Boolean]) extends TransformOps
-case class ResolvedBodyOps(set: Option[Map[Path, Option[JsonValue]]], remove: Option[List[Path]], drop: Option[Boolean])
+case class BodyOps(set: Option[Map[Path, ValueOrRef]], remove: Option[List[Path]], drop: Option[Boolean], nullIfAbsent: Option[Boolean]) extends TransformOps
+case class ResolvedBodyOps(set: Option[Map[Path, Option[JsonValue]]], remove: Option[List[Path]], drop: Option[Boolean], nullIfAbsent: Option[Boolean])
 
 case class PathParamOps(set: Option[Map[String, ValueOrRef]]) extends TransformOps
 case class ResolvedPathParamOps(set: Option[Map[String, Option[String]]])
@@ -33,7 +33,7 @@ case class TransformerConf(body: BodyOps,
 
 object TransformerConf {
   implicit val BodyOpsDecoder: Decoder[BodyOps] = deriveDecoder[BodyOps].emap {
-    case BodyOps(Some(_), _, Some(true)) => Left("Can't both drop body and set body attribute")
+    case BodyOps(Some(_), _, Some(true), _) => Left("Can't both drop body and set body attribute")
     case ops => Right(ops)
   }
   implicit val PathParamOpsDecoder: Decoder[PathParamOps] = deriveDecoder
@@ -43,7 +43,7 @@ object TransformerConf {
   implicit val TransformerConfDecoder: Decoder[TransformerConf] = deriveDecoder[TransformerConfRaw].map {
     rawConf =>
       TransformerConf(
-        body = rawConf.body.getOrElse(BodyOps(None, None, None)),
+        body = rawConf.body.getOrElse(BodyOps(None, None, None, None)),
         parseJsonBody = rawConf.body.nonEmpty || jsonBodyRefExists(rawConf),
         pathParams = rawConf.pathParams.getOrElse(PathParamOps(None)),
         queryParams = rawConf.queryParams.getOrElse(QueryParamOps(None)),

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPlugin.scala
@@ -66,7 +66,7 @@ class TransformRequestPlugin extends RequestPluginVerticle[TransformerConf]
     verticleConf.conf.getOrElse(new JsonObject())
 
   def resolveBodyOps(ctx: RequestCtx, bodyOps: BodyOps, jsonBodyOpt: Option[JsonObject]): ResolvedBodyOps =
-    ResolvedBodyOps(bodyOps.set.map(_.mapValues(resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.remove, bodyOps.drop)
+    ResolvedBodyOps(bodyOps.set.map(_.mapValues(resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.remove, bodyOps.drop, bodyOps.nullIfAbsent)
 
   def resolvePathParamOps(ctx: RequestCtx, pathParamOps: PathParamOps, jsonBodyOpt: Option[JsonObject]): ResolvedPathParamOps =
     ResolvedPathParamOps(pathParamOps.set.map(_.mapValues(ValueResolver.resolveString(ctx, jsonBodyOpt, confValues(), _))))

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/response/TransformResponsePlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/transform/response/TransformResponsePlugin.scala
@@ -60,7 +60,7 @@ class TransformResponsePlugin  extends ResponsePluginVerticle[TransformerConf] {
     verticleConf.conf.getOrElse(new JsonObject())
 
   def resolveBodyOps(ctx: ResponseCtx, bodyOps: BodyOps, jsonBodyOpt: Option[JsonObject]): ResolvedBodyOps =
-    ResolvedBodyOps(bodyOps.set.map(_.mapValues(ValueResolver.resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.remove, bodyOps.drop)
+    ResolvedBodyOps(bodyOps.set.map(_.mapValues(ValueResolver.resolveJson(ctx, jsonBodyOpt, confValues(), _))), bodyOps.remove, bodyOps.drop, bodyOps.nullIfAbsent)
 
   def resolveHeaderOps(ctx: ResponseCtx, headerOps: HeaderOps, jsonBodyOpt: Option[JsonObject]): ResolvedHeaderOps =
     ResolvedHeaderOps(headerOps.set.map(_.mapValues(ValueResolver.resolveListOfStrings(ctx, jsonBodyOpt, confValues(), _))))

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/TransformJsonBodyTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/TransformJsonBodyTest.scala
@@ -86,6 +86,22 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
       val valAtPath = Map(Path("x") -> None)
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
     }
+    "add null in shallow if reference missing" in {
+      val valAtPath = Map(Path("z") -> None)
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("z", null.asInstanceOf[String])
+    }
+    "retain null value in shallow even if nullIfAbsent is false" in {
+      val valAtPath = Map(Path("x") -> Option(NullJsonValue))
+      setJsonBody(valAtPath, Nil, false)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
+    }
+    "remove existing value in shallow if reference missing if nullIfAbsent is false" in {
+      val valAtPath = Map(Path("x") -> None)
+      setJsonBody(valAtPath, Nil, false)(shallowBody) mustBe emptyBody
+    }
+    "omit key in shallow if reference missing if nullIfAbsent is false" in {
+      val valAtPath = Map(Path("z") -> None)
+      setJsonBody(valAtPath, Nil, false)(shallowBody) mustBe shallowBody
+    }
 
     "remove existing value" in {
       val removePath = List(Path("x"))
@@ -200,12 +216,12 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
 
   "TransformJsonBody.applyBodyTransformations" should {
     "return empty buffer if dropping body without set ops" in {
-      val bodyOps = ResolvedBodyOps(set = None, remove = None, drop = Some(true))
+      val bodyOps = ResolvedBodyOps(set = None, remove = None, drop = Some(true), nullIfAbsent = None)
       applyBodyTransformations(bodyOps, new JsonObject().put("x", "y")) mustBe Buffer.buffer()
     }
 
     "return empty buffer if dropping body with set ops" in {
-      val bodyOps = ResolvedBodyOps(set = Some(Map(Path("x") -> Some(StringJsonValue("a")))), remove = None, drop = Some(true))
+      val bodyOps = ResolvedBodyOps(set = Some(Map(Path("x") -> Some(StringJsonValue("a")))), remove = None, drop = Some(true), nullIfAbsent = None)
       applyBodyTransformations(bodyOps, new JsonObject().put("x", "y")) mustBe Buffer.buffer()
     }
   }

--- a/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
+++ b/pyron-plugin/src/main/scala/com/cloudentity/pyron/plugin/util/value/ValueResolver.scala
@@ -193,8 +193,11 @@ object ValueResolver {
   }
 
   private def extractLeafBodyAttribute(body: JsonObject, key: String): Option[JsonValue] = {
-    val value = body.getValue(key)
-    processLeafBodyAttribute(value)
+    if(!body.containsKey(key)) None
+    else {
+      val value = body.getValue(key)
+      processLeafBodyAttribute(value)
+    }
   }
 
   private def processLeafBodyAttribute(value: AnyRef): Option[JsonValue] = {


### PR DESCRIPTION
## [Jira Task](https://cloudentity.atlassian.net/browse/SCMO-9967)

## Description
Allows instances of the transform-request/response plugin to set the `nullIfAbsent` flag to false (true by default). Normally, if an attribute in the `body.set` mapping configuration is not found, an explicit `null` is set in the body under that key. This flag enables dropping the key instead.

## Motivation and Context
See description in JIRA ticket for motivation

## Types of changes
<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
* [ ] Tests (extending the test suite)
* [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests in pyron, usage in Evluma localstack

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] I have added tests to cover my changes
* [x] All new and existing tests passed
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.

## Further comments
<!-- If you're not sure about some decisions, raise questions in this section. -->
<!-- If the PR is big, introduces important changes, isn't obvious -  -->
<!-- explain why you've chosen to implement it this way. -->