### PR TITLE
SCMO-10019-added echo plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### Added
+- Added `echo` plugin
 - Added `remove` section to transform-request/response plugins to remove specific body entries
 - Added `nullIfAbsent` flag (true by default) to transform-request/response plugins to allow disabling setting explicit null if mapped value not found
 - Conditional plugin application for response plugins

--- a/docs/plugins/echo.md
+++ b/docs/plugins/echo.md
@@ -1,0 +1,93 @@
+## Echo plugin
+
+`echo` plugin allows to echo a request without reaching a target service.
+This plugin can be used for usecases like
+- return custom signed jwt as headers
+- echo back transformed request parameters without proxying to target service itself.
+
+```json
+{
+  "default": {
+    "targetHost": "virtual",
+    "targetPort": 0,
+    "pathPrefix": "/firebase/authn/jwt",
+    "dropPrefix": true,
+    "requestPlugins": [{
+      "name": "headerToCtx",
+      "conf": {
+        "headers": [
+          "X-Real-IP"
+        ]
+      }
+    },
+      {
+        "name": "authn",
+        "conf": {
+          "methods": [
+            "sso"
+          ],
+          "entities": [
+            "token",
+            "userUuid",
+            "customerId"
+          ]
+        }
+      }
+    ]
+  },
+  "request": {
+    "postFlow": {
+      "plugins": [{
+        "name": "outgoingCustomJwt",
+        "conf": "$ref:custom-app-config"
+      },
+        {
+          "name": "echo",
+          "conf": {
+            "headers": false,
+            "uri": false,
+            "queryParams": false,
+            "method": false,
+            "headersList": ["Authorization"],
+            "body": false
+          }
+        }
+      ]
+    }
+  },
+  "endpoints": [{
+    "method": "GET",
+    "pathPattern": ".*"
+  }]
+}
+```
+
+Configuration attributes:
+
+| Name            | Description                                                                                                                       |
+|:----------------|:----------------------------------------------------------------------------------------------------------------------------------|
+| headers         | return all headers in response . default is true                                                                                                    |
+| uri             | return uri in response. default is false                                                    |
+| queryParams     | return queryParams in response, default is false                                            |
+| method          | return http method in response. default is false                                             |
+| headersList     | selected headers to return                                                                    |
+| body            | return request body. default is false                 |
+                                                                                             |
+### Example
+
+In the above sample configuration, api sample response would be
+
+```json
+{
+    "headers": {
+        "Authorization": [
+            "Bearer .."
+        ]
+    },
+    "queryParams": "",
+    "uri": "",
+    "method": "",
+    "body": {}
+}
+
+```

--- a/pyron-core/src/main/scala/com/cloudentity/pyron/domain/flow/RequestCtx.scala
+++ b/pyron-core/src/main/scala/com/cloudentity/pyron/domain/flow/RequestCtx.scala
@@ -21,6 +21,7 @@ case class RequestCtx(targetRequest: TargetRequest,
                       aborted: Option[ApiResponse] = None,
                       failed: Option[FlowFailure] = None) {
 
+
   def modifyHeaders(f: Headers => Headers): RequestCtx =
     modifyRequest(v => v.copy(headers = f(v.headers)))
 

--- a/pyron-plugin-impl/src/main/resources/modules/plugin/echo.json
+++ b/pyron-plugin-impl/src/main/resources/modules/plugin/echo.json
@@ -1,0 +1,9 @@
+{
+  "registry:request-plugins": {
+    "echo": {
+      "main": "com.cloudentity.pyron.plugin.impl.echo.EchoPlugin",
+      "verticleConfig": {
+      }
+    }
+  }
+}

--- a/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/echo/EchoPlugin.scala
+++ b/pyron-plugin-impl/src/main/scala/com/cloudentity/pyron/plugin/impl/echo/EchoPlugin.scala
@@ -1,0 +1,85 @@
+package com.cloudentity.pyron.plugin.impl.echo
+
+import com.cloudentity.pyron.domain.flow.{PluginName, RequestCtx}
+import com.cloudentity.pyron.domain.http.{ApiResponse, Headers}
+import com.cloudentity.pyron.plugin.config.{ValidateOk, ValidateResponse}
+import com.cloudentity.pyron.plugin.verticle.RequestPluginVerticle
+import com.cloudentity.pyron.util.ConfigDecoder
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.vertx.core.json.JsonObject
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+case class EchoPluginConf( headers: Option[Boolean], body: Option[Boolean],
+                           uri: Option[Boolean], method: Option[Boolean],
+                           queryParams: Option[Boolean],
+                           host: Option[Boolean],
+                           headersList: Option[List[String]])
+
+object EchoPluginConf {
+  val default = EchoSettings(headers = Some(true), body = Some(false), uri = Some(false),
+    method = Some(false), queryParams = Some(false), host = Some(false), headersList = Some(List()))
+}
+
+case class EchoSettings(headers: Option[Boolean], body: Option[Boolean], uri: Option[Boolean], method: Option[Boolean],
+                        queryParams: Option[Boolean], host: Option[Boolean], headersList: Option[List[String]])
+
+class EchoPlugin extends RequestPluginVerticle[EchoPluginConf] with ConfigDecoder {
+  override def name: PluginName = PluginName("echo")
+  override def apply(requestCtx: RequestCtx, conf: EchoPluginConf): Future[RequestCtx] = {
+    val j =  new JsonObject()
+      .put("headers", headersAsJsonObject(conf, requestCtx.targetRequest.headers))
+      .put("queryParams", queryParamsResponse(conf, requestCtx))
+      .put("uri", uriResponse(conf, requestCtx))
+      .put("method", methodResponse(conf, requestCtx))
+      .put("body", bodyResponse(conf, requestCtx))
+    log.debug(requestCtx.tracingCtx, s"Response: $j")
+    Future.successful(requestCtx.abort(ApiResponse(200, j.toBuffer, Headers.empty().set("content-type", "application/json"))))
+  }
+
+  def headersAsJsonObject(conf: EchoPluginConf, httpHeaders: Headers): JsonObject = {
+    if(conf.headers.getOrElse(true)) {
+      httpHeaders.toMap.foldLeft(new JsonObject())((json,mapElem) => json.put(mapElem._1, mapElem._2.asJava))
+    } else {
+      httpHeaders.toMap.foldLeft(new JsonObject())((json,mapElem) => {
+        if(conf.headersList.contains(mapElem._1)) {
+          json.put(mapElem._1, mapElem._2.asJava)
+        } else json
+      })
+    }
+  }
+
+  def bodyResponse(conf: EchoPluginConf, requestCtx: RequestCtx): JsonObject = {
+    if(conf.body.getOrElse(false)) {
+      new JsonObject(requestCtx.targetRequest.bodyOpt.get)
+    } else new JsonObject()
+  }
+
+  def uriResponse(conf: EchoPluginConf, requestCtx: RequestCtx): String = {
+    if(conf.uri.getOrElse(false)) {
+      requestCtx.targetRequest.uri.path
+    } else ""
+  }
+
+  def methodResponse(conf: EchoPluginConf, requestCtx: RequestCtx): String = {
+    if(conf.method.getOrElse(false)) {
+      requestCtx.targetRequest.method.toString
+    } else ""
+  }
+
+  def queryParamsResponse(conf: EchoPluginConf, requestCtx: RequestCtx): String = {
+    if(conf.queryParams.getOrElse(false)) {
+      requestCtx.targetRequest.uri.query.toString
+    } else ""
+  }
+
+  def headerAsJson(requestCtx: RequestCtx) = {
+    requestCtx.targetRequest.headers.toMap
+  }
+
+  override def validate(conf: EchoPluginConf): ValidateResponse = ValidateOk
+
+  override def confDecoder: Decoder[EchoPluginConf] = deriveDecoder
+}

--- a/pyron-plugin-impl/src/test/resources/plugins/echo/config.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/echo/config.json
@@ -1,0 +1,15 @@
+{
+  "app": {
+    "port": 8080,
+    "serverVerticles": 1
+  },
+  "registry:request-plugins": {
+    "plugin:echo": {
+      "main": "com.cloudentity.pyron.plugin.impl.echo.EchoPlugin",
+      "verticleConfig": {
+      }
+    }
+  },
+  "registry:response-plugins": {
+  }
+}

--- a/pyron-plugin-impl/src/test/resources/plugins/echo/meta-config.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/echo/meta-config.json
@@ -1,0 +1,19 @@
+{
+  "scanPeriod": 5000,
+  "stores": [
+    {
+      "type": "file",
+      "format": "json",
+      "config": {
+        "path": "src/test/resources/plugins/echo/config.json"
+      }
+    },
+    {
+      "type": "file",
+      "format": "json",
+      "config": {
+        "path": "src/test/resources/plugins/echo/rules.json"
+      }
+    }
+  ]
+}

--- a/pyron-plugin-impl/src/test/resources/plugins/echo/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/echo/rules.json
@@ -1,0 +1,78 @@
+{
+  "rules": [
+    {
+      "default": {
+        "targetHost": "localhost",
+        "targetPort": 7760
+      },
+      "request": {
+        "preFlow": {
+          "plugins": [
+            {
+              "name": "echo"
+            }
+          ]
+        }
+      },
+      "endpoints": [
+        {
+          "method": "GET",
+          "pathPattern": "/echotest"
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/echotest2",
+          "requestPlugins": [
+            {
+              "name": "echo",
+              "conf": {
+              }
+            }
+          ]
+        },
+        {
+          "method": "GET",
+          "pathPattern": "/echotest3",
+          "requestPlugins": [
+            {
+              "name": "echo",
+              "conf": {
+                "headers": false,
+                "uri": true,
+                "queryParams": true,
+                "method": true,
+                "headersList": ["test-header"]
+              }
+            }
+          ],
+          "request": {
+            "preFlow": {
+              "disablePlugins": ["echo"]
+            }
+          }
+        },
+        {
+          "method": "POST",
+          "pathPattern": "/echotest4",
+          "requestPlugins": [
+            {
+              "name": "echo",
+              "conf": {
+                "headers": false,
+                "uri": true,
+                "queryParams": true,
+                "method": true,
+                "headersList": ["test-header"]
+              }
+            }
+          ],
+          "request": {
+            "preFlow": {
+              "disablePlugins": ["echo"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/echo/EchoPluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/echo/EchoPluginTest.scala
@@ -1,0 +1,96 @@
+package com.cloudentity.pyron.plugin.impl.echo
+
+import com.cloudentity.pyron.plugin.impl.PluginAcceptanceTest
+import io.restassured.RestAssured.`given`
+import io.restassured.http.{Header, Headers, Method}
+import org.json.JSONObject
+import org.junit.{After, Before, Test}
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.HttpRequest
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.scalatest.MustMatchers
+import org.skyscreamer.jsonassert.JSONAssert
+
+class EchoPluginTest extends PluginAcceptanceTest with MustMatchers {
+  var targetService: ClientAndServer = _
+
+  @Before
+  def before(): Unit = {
+    targetService = startClientAndServer(7760)
+    targetService.when(request()).callback { request: HttpRequest =>
+      response().withStatusCode(200)
+    }
+  }
+
+  @After
+  def finish(): Unit = {
+    targetService.stop
+  }
+
+  override def getMetaConfPath(): String = "src/test/resources/plugins/echo/meta-config.json"
+
+  @Test
+  def shouldInjectAccessControlHeadersToResponseWithBody(): Unit = {
+
+    val inputHeaders = Headers.headers(new Header("test-header", "test-value"))
+    val testBody = new JSONObject().put("some", "key")
+
+    val jsonObject = new JSONObject(
+      """ {"headers":{"test-header":["test-value"]},
+        |"queryParams":"","uri":"/echotest4","method":"POST",
+        | "body" : { "some" : "key"}}  """.stripMargin)
+
+    callWithBody("http://example.com", Method.POST, "/echotest4", inputHeaders, testBody, jsonObject, 200)
+  }
+
+  @Test
+  def shouldInjectAccessControlHeadersToResponseWithSelectedHeader(): Unit = {
+
+    val inputHeaders = Headers.headers(new Header("test-header", "test-value"))
+    val jsonObject = new JSONObject(
+      """ {"headers":{"test-header":["test-value"]},
+        |"queryParams":"",
+        |"uri":"/echotest3",
+        |"method":"GET",
+        |"body" :{}}  """.stripMargin)
+    call("http://example.com", Method.GET, "/echotest3", inputHeaders, jsonObject, 200)
+  }
+
+  val expectedWildcardHeaders = Map(
+    "asd" -> "asdf"
+  )
+
+  def call(origin: String, method: Method, path: String, headers: Headers, jsonObject: JSONObject, expectedStatus: Int) = {
+
+    val response  = given()
+      .when()
+      .headers(headers)
+      .request(method, path)
+      .`then`()
+      .statusCode(expectedStatus)
+      .contentType("application/json")
+      .extract().response()
+
+    JSONAssert.assertEquals("checking json", response.body().asString(), jsonObject, false)
+
+  }
+
+  def callWithBody(origin: String, method: Method, path: String, headers: Headers, body: JSONObject,  jsonObject: JSONObject, expectedStatus: Int) = {
+
+    val response  = given()
+      .body(body.toString)
+      .when()
+      .headers(headers)
+      .request(method, path)
+      .`then`()
+      .statusCode(expectedStatus)
+      .contentType("application/json")
+      .extract().response()
+
+    JSONAssert.assertEquals("checking json", response.body().asString(), jsonObject, false)
+
+  }
+
+}


### PR DESCRIPTION
## [SCMO-10019](added echo plugin)

## Description
New pyron plugin to echo the request headers and body

## Motivation and Context
This was added to echo back internally created asymmetrically signed jwt(as headers in json body) to applications. This will help to solve a usecase for Google firebase authentication wherein an application can request for an asymmetrically signed jwt from Pyron itself(protected within a specific authn method before minting the firebase jwt)

## Types of changes
- new pyron plugin

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
* [x ] Tests (extending the test suite)
* [ x] Documentation Update (if none of the other choices apply)
