### PR TITLE
SCMO-10071 Added 'setWithDefault' to transform-request/response plugins for setting default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- Added `setWithDefault` to transform-request/response plugins for setting default values
+
 ## [1.12.0] - 2021-09-29
 ### Fixed
 - Bruteforce plugin identifier case sensitivity is configurable at plugin level. Default is for identifiers to be case insensitive but can be overriden

--- a/pyron-plugin-impl/src/test/resources/plugins/transform-request/rules.json
+++ b/pyron-plugin-impl/src/test/resources/plugins/transform-request/rules.json
@@ -243,6 +243,41 @@
         },
         {
           "method": "POST",
+          "pathPattern": "/body-set-with-default",
+          "requestPlugins": [
+            {
+              "name": "transform-request",
+              "conf": {
+                "body": {
+                  "setWithDefault": {
+                    "attr1": {
+                      "sourcePath": "$body.attr1",
+                      "ifNull": {"value": "itHadBeenNull"},
+                      "ifAbsent": {"value": "itHadBeenAbsent"}
+                    },
+                    "attr2": {
+                      "sourcePath": "$body.attr2"
+                    },
+                    "attr3": {
+                      "sourcePath": "$body.attr3",
+                      "ifNull": {"remove": true},
+                      "ifAbsent": {"value": ["itHadBeenAbsent"]}
+                    },
+                    "attr4": {
+                      "sourcePath": "$body.attr4",
+                      "ifNull": {"value": {
+                        "subValue": "itHadBeenNull"
+                      }},
+                      "ifAbsent": {"remove": true}
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "method": "POST",
           "pathPattern": "/body-dropped",
           "requestPlugins": [
             {

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/TransformJsonBodyTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/TransformJsonBodyTest.scala
@@ -2,6 +2,7 @@ package com.cloudentity.pyron.plugin.impl.transform
 
 import com.cloudentity.pyron.plugin.impl.transform.TransformJsonBody.{applyBodyTransformations, setJsonBody}
 import com.cloudentity.pyron.plugin.util.value._
+import com.cloudentity.pyron.plugin.util.value.{JsonValueIgnoreNullIfDefault => JsonWrap}
 import com.cloudentity.pyron.test.TestRequestResponseCtx
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.json.{JsonArray, JsonObject}
@@ -17,90 +18,102 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
     def emptyBody = new JsonObject()
 
     "set string value in empty body" in {
-      val valAtPath = Map(Path("a") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(StringJsonValue("string"))))
       setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", "string")
     }
     "set string value deep in empty body" in {
-      val valAtPath = Map(Path("a", "b") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("a", "b") -> JsonWrap(Option(StringJsonValue("string"))))
       setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", emptyBody.put("b", "string"))
     }
     "set json object value in empty body" in {
       val obj = new JsonObject().put("x", "y")
-      val valAtPath = Map(Path("a") -> Option(ObjectJsonValue(obj.copy())))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(ObjectJsonValue(obj.copy()))))
       setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", obj.copy())
     }
     "set json array value in empty body" in {
       val arr = new JsonArray().add("x")
-      val valAtPath = Map(Path("a") -> Option(ArrayJsonValue(arr.copy())))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(ArrayJsonValue(arr.copy()))))
       setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", arr.copy())
     }
     "set null value in empty body" in {
-      val valAtPath = Map(Path("a") -> Option(NullJsonValue))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(NullJsonValue)))
       setJsonBody(valAtPath, Nil)(emptyBody) mustBe emptyBody.put("a", null.asInstanceOf[String])
     }
 
     def shallowBody = new JsonObject().put("x", "value")
 
     "set string value in shallow" in {
-      val valAtPath = Map(Path("a") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(StringJsonValue("string"))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", "string")
     }
     "set string value deep in shallow" in {
-      val valAtPath = Map(Path("a", "b") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("a", "b") -> JsonWrap(Option(StringJsonValue("string"))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", new JsonObject().put("b", "string"))
     }
     "set json object value in shallow" in {
       val obj = new JsonObject().put("x", "y")
-      val valAtPath = Map(Path("a") -> Option(ObjectJsonValue(obj.copy())))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(ObjectJsonValue(obj.copy()))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", obj.copy())
     }
     "set json array value in shallow" in {
       val arr = new JsonArray().add("x")
-      val valAtPath = Map(Path("a") -> Option(ArrayJsonValue(arr.copy())))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(ArrayJsonValue(arr.copy()))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", arr.copy())
     }
     "set null value in shallow" in {
-      val valAtPath = Map(Path("a") -> Option(NullJsonValue))
+      val valAtPath = Map(Path("a") -> JsonWrap(Option(NullJsonValue)))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("a", null.asInstanceOf[String])
     }
 
     "overwrite with string value in shallow" in {
-      val valAtPath = Map(Path("x") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(StringJsonValue("string"))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", "string")
     }
     "overwrite with json object value in shallow" in {
       val obj = new JsonObject().put("u", "v")
-      val valAtPath = Map(Path("x") -> Option(ObjectJsonValue(obj.copy())))
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(ObjectJsonValue(obj.copy()))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", obj.copy())
     }
     "overwrite with json array value in shallow" in {
       val arr = new JsonArray().add("x")
-      val valAtPath = Map(Path("x") -> Option(ArrayJsonValue(arr.copy())))
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(ArrayJsonValue(arr.copy()))))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", arr.copy())
     }
     "overwrite with null value in shallow" in {
-      val valAtPath = Map(Path("x") -> Option(NullJsonValue))
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(NullJsonValue)))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
     }
     "overwrite with null in shallow if reference missing" in {
-      val valAtPath = Map(Path("x") -> None)
+      val valAtPath = Map(Path("x") -> JsonWrap(None))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
     }
     "add null in shallow if reference missing" in {
-      val valAtPath = Map(Path("z") -> None)
+      val valAtPath = Map(Path("z") -> JsonWrap(None))
       setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody.put("z", null.asInstanceOf[String])
     }
     "retain null value in shallow even if nullIfAbsent is false" in {
-      val valAtPath = Map(Path("x") -> Option(NullJsonValue))
-      setJsonBody(valAtPath, Nil, false)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(NullJsonValue)))
+      setJsonBody(valAtPath, Nil, nullIfAbsent = false)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
     }
     "remove existing value in shallow if reference missing if nullIfAbsent is false" in {
-      val valAtPath = Map(Path("x") -> None)
-      setJsonBody(valAtPath, Nil, false)(shallowBody) mustBe emptyBody
+      val valAtPath = Map(Path("x") -> JsonWrap(None))
+      setJsonBody(valAtPath, Nil, nullIfAbsent = false)(shallowBody) mustBe emptyBody
     }
     "omit key in shallow if reference missing if nullIfAbsent is false" in {
-      val valAtPath = Map(Path("z") -> None)
-      setJsonBody(valAtPath, Nil, false)(shallowBody) mustBe shallowBody
+      val valAtPath = Map(Path("z") -> JsonWrap(None))
+      setJsonBody(valAtPath, Nil, nullIfAbsent = false)(shallowBody) mustBe shallowBody
+    }
+    "retain null value in shallow even if ignoreNullIfAbsent is true" in {
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(NullJsonValue), ignoreNullIfAbsent = true))
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody.put("x", null.asInstanceOf[String])
+    }
+    "remove existing value in shallow if reference missing if ignoreNullIfAbsent is true" in {
+      val valAtPath = Map(Path("x") -> JsonWrap(None, ignoreNullIfAbsent = true))
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe emptyBody
+    }
+    "omit key in shallow if reference missing if ignoreNullIfAbsent is true" in {
+      val valAtPath = Map(Path("z") -> JsonWrap(None, ignoreNullIfAbsent = true))
+      setJsonBody(valAtPath, Nil)(shallowBody) mustBe shallowBody
     }
 
     "remove existing value" in {
@@ -109,13 +122,13 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
     }
 
     "remove existing value while adding new" in {
-      val valAtPath = Map(Path("y") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("y") -> JsonWrap(Option(StringJsonValue("string"))))
       val removePath = List(Path("x"))
       setJsonBody(valAtPath, removePath)(shallowBody) mustBe emptyBody.put("y", "string")
     }
 
     "remove existing value while replacing" in {
-      val valAtPath = Map(Path("x") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("x") -> JsonWrap(Option(StringJsonValue("string"))))
       val removePath = List(Path("x"))
       setJsonBody(valAtPath, removePath)(shallowBody) mustBe emptyBody
     }
@@ -123,29 +136,29 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
     def complexBody = new JsonObject(""" { "x": "value", "y" : { "z": "value" } } """)
 
     "overwrite with string value in complex body" in {
-      val valAtPath = Map(Path("y", "z") -> Option(StringJsonValue("string")))
+      val valAtPath = Map(Path("y", "z") -> JsonWrap(Option(StringJsonValue("string"))))
       setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": "string" } } """)
     }
     "overwrite with json object value in complex body" in {
       val obj = new JsonObject().put("u", "v")
-      val valAtPath = Map(Path("y", "z") -> Option(ObjectJsonValue(obj)))
+      val valAtPath = Map(Path("y", "z") -> JsonWrap(Option(ObjectJsonValue(obj))))
       setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": { "u" : "v" } } } """)
     }
     "overwrite with json array value in complex body" in {
       val arr = new JsonArray().add("u")
-      val valAtPath = Map(Path("y", "z") -> Option(ArrayJsonValue(arr)))
+      val valAtPath = Map(Path("y", "z") -> JsonWrap(Option(ArrayJsonValue(arr))))
       setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": [ "u" ] } } """)
     }
     "overwrite with null value in complex body" in {
-      val valAtPath = Map(Path("y", "z") -> Option(NullJsonValue))
+      val valAtPath = Map(Path("y", "z") -> JsonWrap(Option(NullJsonValue)))
       setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": null } } """)
     }
     "overwrite with null in complex deep if reference missing" in {
-      val valAtPath = Map(Path("y", "z") -> None)
+      val valAtPath = Map(Path("y", "z") -> JsonWrap(None))
       setJsonBody(valAtPath, Nil)(complexBody) mustBe
         new JsonObject(""" { "x": "value", "y" : { "z": null } } """)
     }
@@ -216,12 +229,12 @@ class TransformJsonBodyTest extends WordSpec with MustMatchers with TestRequestR
 
   "TransformJsonBody.applyBodyTransformations" should {
     "return empty buffer if dropping body without set ops" in {
-      val bodyOps = ResolvedBodyOps(set = None, remove = None, drop = Some(true), nullIfAbsent = None)
+      val bodyOps = ResolvedBodyOps(set = Map.empty, remove = None, drop = Some(true), nullIfAbsent = None)
       applyBodyTransformations(bodyOps, new JsonObject().put("x", "y")) mustBe Buffer.buffer()
     }
 
     "return empty buffer if dropping body with set ops" in {
-      val bodyOps = ResolvedBodyOps(set = Some(Map(Path("x") -> Some(StringJsonValue("a")))), remove = None, drop = Some(true), nullIfAbsent = None)
+      val bodyOps = ResolvedBodyOps(set = Map(Path("x") -> JsonWrap(Some(StringJsonValue("a")))), remove = None, drop = Some(true), nullIfAbsent = None)
       applyBodyTransformations(bodyOps, new JsonObject().put("x", "y")) mustBe Buffer.buffer()
     }
   }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPluginAcceptanceTest.scala
@@ -224,6 +224,85 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
   }
 
   @Test
+  def shouldSetBodyAttributeFromBodyAllAbsent(): Unit = {
+    val input = """{}"""
+    val expectedOutput = compactJsonObject(
+      """{
+       |  "attr1": "itHadBeenAbsent",
+       |  "attr3": ["itHadBeenAbsent"]
+       |}""".stripMargin)
+
+    given()
+      .body(input)
+      .when()
+      .post("/body-set-with-default")
+      .`then`()
+      .statusCode(200)
+
+    assertTargetRequest { req =>
+      req.getBodyAsString mustBe expectedOutput
+    }
+  }
+
+  @Test
+  def shouldSetBodyAttributeFromBodyAllNull(): Unit = {
+    val input ="""{
+        |  "attr1": null,
+        |  "attr2": null,
+        |  "attr3": null,
+        |  "attr4": null
+        |}""".stripMargin
+
+    val expectedOutput = compactJsonObject(
+      """{
+        |  "attr1": "itHadBeenNull",
+        |  "attr2": null,
+        |  "attr4": {
+        |    "subValue": "itHadBeenNull"
+        |  }
+        |}""".stripMargin)
+
+    given()
+      .body(input)
+      .when()
+      .post("/body-set-with-default")
+      .`then`()
+      .statusCode(200)
+
+    assertTargetRequest { req =>
+      req.getBodyAsString mustBe expectedOutput
+    }
+  }
+
+  @Test
+  def shouldSetBodyAttributeFromBodyAllPresent(): Unit = {
+    val input ="""{
+        |  "attr1": "value1",
+        |  "attr2": "value2",
+        |  "attr3": "value3",
+        |  "attr4": "value4"
+        |}""".stripMargin
+    val expectedOutput = compactJsonObject(
+      """{
+        |  "attr1": "value1",
+        |  "attr2": "value2",
+        |  "attr3": "value3",
+        |  "attr4": "value4"
+        |}""".stripMargin)
+
+    given()
+      .body(input)
+      .when()
+      .post("/body-set-with-default")
+      .`then`()
+      .statusCode(200)
+
+    assertTargetRequest { req =>
+      req.getBodyAsString mustBe expectedOutput
+    }
+  }
+
+  @Test
   def shouldDropBody(): Unit = {
     given()
       .body("""{"attr":"x"}""")
@@ -489,4 +568,6 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
     targetService.retrieveRecordedRequests(null).length mustBe 1
     f(targetService.retrieveRecordedRequests(null)(0))
   }
+
+  def compactJsonObject(input: String): String = new io.vertx.core.json.JsonObject(input).toString
 }


### PR DESCRIPTION
## [Jira Task](https://cloudentity.atlassian.net/browse/SCMO-10071)
## [Upstream Jira Task](https://cloudentity.atlassian.net/browse/EVL-464)

## Description
This change adds a new configuration section to the transform-request and transform-response body plugins. `setWithDefault` supplements the `set` configuration block by allowing default values, in case a resolved attribute is null or absent from the JSON body.

The `setWithDefault` config follows a similar structure to the `set` config, except that the values of each entry explicitly identify the source reference, and what to do if the value were null or absent.

## Motivation and Context
For Evluma, it is required that certain fields of the license object embedded into a Self Get User API response return a default value if not present. Since these fields are derived through other API Gateway plugins, defaults need to be able to be set at the API Gateway level. Also, it's just a cool feature.

## Types of changes
<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
* [ ] Tests (extending the test suite)
* [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?
* Unit tests in pyron
* Integration tests in pyron
* Applied in localstack msaas-evluma and verified using Postman tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] I have added tests to cover my changes
* [x] All new and existing tests passed
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.