### PR TITLE
Handle multiple comma-separated values in single X-Forwarded-For header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Added possibility set the application port using $PORT env variable
 
 ### Fixed
-- Comma-separated X-Forwarded-For values in single header recognized and set as proper X-Real-IP
+- Comma-separated X-Forwarded-For and X-Real-IP values in single header recognized and set as proper X-Real-IP
+- X-Real-IP headers are not modified if already set
 
 
 ## [1.13.0] - 2021-10-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Cloudentity user ID to 9999
 - Added possibility set the application port using $PORT env variable
 
+### Fixed
+- Comma-separated X-Forwarded-For values in single header recognized and set as proper X-Real-IP
+
+
 ## [1.13.0] - 2021-10-19
 ### Added
 - Added `setWithDefault` to transform-request/response plugins for setting default values, and documentation

--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ Pyron applies following request headers modification (unless disabled):
 * Add `remote-address.protocol` to `X-Forwarded-Proto` headers
 * If `Host` header is set then add it to `X-Forwarded-Host` headers
 * If True Client IP header is missing then set it to first `X-Forwarded-For` value
-* Set True Client IP header to upstream service
+* Set True Client IP header to upstream service if not set already
 
 | Env variable                      | Description                                            |
 |:----------------------------------|:-------------------------------------------------------|

--- a/pyron-engine/src/main/scala/com/cloudentity/pyron/api/ProxyHeadersHandler.scala
+++ b/pyron-engine/src/main/scala/com/cloudentity/pyron/api/ProxyHeadersHandler.scala
@@ -31,7 +31,12 @@ object ProxyHeadersHandler {
     val trueClientIpOpt  = Option(headers.get(proxyHeaderNames.inputTrueClientIp.getOrElse(defaultTrueClientIpHeader)))
     val realIp           = trueClientIpOpt match {
                              case Some(ip) => ip
-                             case None => Option(headers.get(xForwardedForHeader)).getOrElse(remoteIp)
+                             case None =>
+                               Option(headers.get(xForwardedForHeader))
+                                  // covers case when X-Forwarded-For values are comma-separated in single header value (like in nginx)
+                                  // e.g. given 'X-Forwarded-For: 203.0.113.195, 70.41.3.18, 150.172.238.178' extracts '203.0.113.195'
+                                 .flatMap(_.split(",").headOption).map(_.trim)
+                                 .getOrElse(remoteIp)
                            }
 
     val proxyHeaders: Map[String, List[String]] =

--- a/pyron-engine/src/main/scala/com/cloudentity/pyron/api/ProxyHeadersHandler.scala
+++ b/pyron-engine/src/main/scala/com/cloudentity/pyron/api/ProxyHeadersHandler.scala
@@ -28,16 +28,14 @@ object ProxyHeadersHandler {
     val remoteIp         = remoteHost
     val remoteHostOpt    = host
     val protocol         = if (ssl) "https" else "http"
-    val trueClientIpOpt  = Option(headers.get(proxyHeaderNames.inputTrueClientIp.getOrElse(defaultTrueClientIpHeader)))
-    val realIp           = trueClientIpOpt match {
-                             case Some(ip) => ip
-                             case None =>
-                               Option(headers.get(xForwardedForHeader))
-                                  // covers case when X-Forwarded-For values are comma-separated in single header value (like in nginx)
-                                  // e.g. given 'X-Forwarded-For: 203.0.113.195, 70.41.3.18, 150.172.238.178' extracts '203.0.113.195'
-                                 .flatMap(_.split(",").headOption).map(_.trim)
-                                 .getOrElse(remoteIp)
-                           }
+
+    val realIpInHeader   = proxyHeaderNames.inputTrueClientIp.getOrElse(defaultTrueClientIpHeader)
+    val realIpOutHeader  = proxyHeaderNames.outputTrueClientIp.getOrElse(defaultTrueClientIpHeader)
+    val realIpHeaderVals = headers.getAll(realIpInHeader).asScala.toList
+
+    val realIp           = getFirstValueWithCommaSeparator(headers, realIpInHeader)
+                             .orElse(getFirstValueWithCommaSeparator(headers, xForwardedForHeader))
+                             .getOrElse(remoteIp)
 
     val proxyHeaders: Map[String, List[String]] =
       if (proxyHeaderNames.enabled.getOrElse(true)) {
@@ -45,7 +43,7 @@ object ProxyHeadersHandler {
           xForwardedForHeader   -> (headers.getAll(xForwardedForHeader).asScala.toList ::: List(remoteIp)),
           xForwardedHostHeader  -> (headers.getAll(xForwardedHostHeader).asScala.toList ::: remoteHostOpt.toList),
           xForwardedProtoHeader -> (headers.getAll(xForwardedProtoHeader).asScala.toList ::: List(protocol)),
-          proxyHeaderNames.outputTrueClientIp.getOrElse(defaultTrueClientIpHeader) -> List(realIp)
+          realIpOutHeader       -> realIpHeaderVals.headOption.fold(List(realIp))(_ => realIpHeaderVals)
         )
       } else Map()
 
@@ -54,6 +52,11 @@ object ProxyHeadersHandler {
       trueClientIp = realIp
     )
   }
+
+  // gets first header value taking into account that a single header can contain multiple comma-separated values (like in nging),
+  // e.g. given 'X-Forwarded-For: 203.0.113.195, 70.41.3.18' 'X-Forwarded-For: 150.172.238.178' extracts '203.0.113.195'
+  private def getFirstValueWithCommaSeparator(headers: MultiMap, headerName: String): Option[String] =
+    headers.getAll(headerName).asScala.toList.flatMap(_.split(",")).map(_.trim).headOption
 
   def getProxyHeaders(ctx: RoutingContext): Option[ProxyHeaders] =
     Try(ctx.get[ProxyHeaders](proxyHeadersKey)).toOption.flatMap(Option.apply)

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ProxyHeadersHandlerAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ProxyHeadersHandlerAcceptanceTest.scala
@@ -154,4 +154,26 @@ class ProxyHeadersHandlerAcceptanceTest  extends PyronAcceptanceTest with MustMa
 
     ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
   }
+
+  @Test
+  def shouldExtractTrueClientIpWhenXForwardedForValuesAreCommaSeparated(): Unit = {
+    // given
+    val headerNames = ProxyHeaderConf(None, None, None)
+    val trueIp = "203.0.113.195"
+    val headers =
+      MultiMap.caseInsensitiveMultiMap
+        .add(xForwardedForHeader, s"$trueIp, 70.41.3.18, 150.172.238.178")
+        .add(xForwardedForHeader, "55.65.3.17")
+
+    // when then
+    val expectedHeaders = Map(
+      xForwardedForHeader       -> List(s"$trueIp, 70.41.3.18, 150.172.238.178", "55.65.3.17", remoteIp),
+      xForwardedHostHeader      -> List(remoteHost),
+      xForwardedProtoHeader     -> List("http"),
+      defaultTrueClientIpHeader -> List(trueIp)
+    )
+    val expectedTrueClientIp = trueIp
+
+    ProxyHeadersHandler.proxyHeaders(headers, remoteIp, Option(remoteHost), ssl = false, headerNames) mustBe ProxyHeaders(expectedHeaders, expectedTrueClientIp)
+  }
 }


### PR DESCRIPTION
## Jira task - SCMO-10112

## Description
Pyron handles comma-separated X-Forwarded-For values in single header and sets proper X-Real-IP

<!--- Describe what this feature does
  REQUIRED
  USED IN RELEASE NOTES
-->

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
