### PR TITLE
SCMO-10151 Vulnerability Squashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [Unreleased]
+### Security
+- [CVE-2020-13949](https://nvd.nist.gov/vuln/detail/CVE-2020-13949)
+  - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively libthrift 0.13.0 -> 0.14.1)
+  - Avoiding importing tomcat-embed-core 8.5.46, with its new vulnerabilities, by setting overriding libthrift -> 0.16.0
+- [CVE-2022-21653](https://nvd.nist.gov/vuln/detail/CVE-2022-21653)
+  - Upgrading circe 0.11.1 to 0.14.1 (transitively jawn-parser 0.14.1 -> 1.1.2)
+  - Upgrading jawn-parser -> 1.3.2 to solve vulnerability
+- [CVE-2021-29425](https://nvd.nist.gov/vuln/detail/CVE-2021-29425) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively commons-io 2.5 -> 2.11.0)
+- [CVE-2018-12541](https://nvd.nist.gov/vuln/detail/CVE-2018-12541) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively vertx 3.9.5 -> 3.9.12)
+- [CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively netty-transport and netty-handler 4.1.49 -> 4.1.72)
+- [CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively netty-transport and netty-handler 4.1.49 -> 4.1.72)
+- [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively netty-transport and netty-handler 4.1.49 -> 4.1.72)
+- [CVE-2021-37136](https://nvd.nist.gov/vuln/detail/CVE-2021-37136) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively netty-transport and netty-handler 4.1.49 -> 4.1.72)
+- [CVE-2021-37137](https://nvd.nist.gov/vuln/detail/CVE-2021-37137) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively netty-transport and netty-handler 4.1.49 -> 4.1.72)
+- [CVE-2021-43797](https://nvd.nist.gov/vuln/detail/CVE-2021-43797) - Solved by upgrading vertx-tools 1.9.0 -> 1.11.0 (transitively netty-transport and netty-handler 4.1.49 -> 4.1.72)
+- [CVE-2020-29582](https://nvd.nist.gov/vuln/detail/CVE-2020-29582) - Solved by upgrading kotlin-stdlib and kotlin-stdlib-common from 1.3.50 -> 1.4.32
+- [CVE-2020-15824](https://nvd.nist.gov/vuln/detail/CVE-2020-15824) - Solved by upgrading kotlin-stdlib and kotlin-stdlib-common from 1.3.50 -> 1.4.32
+- [CVE-2017-18640](https://nvd.nist.gov/vuln/detail/CVE-2017-18640) - Fixed by upgrading swagger-parser 1.0.36 -> 1.0.58 (transitively snakeyaml 1.18 -> 1.26)
+- [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) - Solved by upgrading rest-assured 3.0.2 -> 4.5.1 and httpclient 4.5.3 -> 4.5.13
+- [CVE-2018-1000873](https://nvd.nist.gov/vuln/detail/CVE-2018-1000873) - Solved by upgrading mock-server 5.1.1 -> 5.9.0 (transitively jackson-annotations 2.9.2 -> 2.10.1)
+- [CWE-79](http://cwe.mitre.org/data/definitions/79.html) - Solved by upgrading scala-reflect 2.12.6 and 2.12.8 -> 2.12.9 (matching scala-library version)
+
 ## [1.14.0] - 2021-11-19
 ### Changed
 - Updated base docker image to openjdk:8u312-jre

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <circe.version>0.14.1</circe.version>
     <embedded-consul.version>1.0.0</embedded-consul.version>
     <slf4j.version>1.8.0-beta4</slf4j.version>
-    <bouncycastle.bcprov.version>1.62</bouncycastle.bcprov.version>
     <apache.httpclient.version>4.5.13</apache.httpclient.version>
     <nimbus.version>8.22.1</nimbus.version>
     <libthrift.version>0.16.0</libthrift.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,17 +26,22 @@
     <java.version>1.8</java.version>
 
     <!-- compile -->
-    <vertx-tools.version>1.9.0</vertx-tools.version>
-    <circe.version>0.11.1</circe.version>
+    <vertx-tools.version>1.11.0-SNAPSHOT</vertx-tools.version>
+    <circe.version>0.14.1</circe.version>
     <embedded-consul.version>1.0.0</embedded-consul.version>
     <slf4j.version>1.8.0-beta4</slf4j.version>
     <bouncycastle.bcprov.version>1.62</bouncycastle.bcprov.version>
-    <apache.httpclient.version>4.5.6</apache.httpclient.version>
+    <apache.httpclient.version>4.5.13</apache.httpclient.version>
     <nimbus.version>8.22.1</nimbus.version>
+    <libthrift.version>0.16.0</libthrift.version>
+    <kotlin.version>1.4.32</kotlin.version>
+    <jawn.version>1.3.2</jawn.version>
+    <swagger-parser.version>1.0.58</swagger-parser.version>
+    <rest-assured.version>4.5.1</rest-assured.version>
 
     <!-- test -->
     <scala-test.version>3.1.0-RC1</scala-test.version>
-    <mock-server.version>5.1.1</mock-server.version>
+    <mock-server.version>5.9.0</mock-server.version>
 
     <!-- plugins -->
     <scala-maven-plugin.version>4.2.0</scala-maven-plugin.version>
@@ -47,8 +52,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
     <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
-    <dependency-check-maven.version>5.2.1</dependency-check-maven.version>
-    <owaspdt.url>https://owaspdt.int.cloudentity.com</owaspdt.url>
+    <dependency-check-maven.version>6.5.3</dependency-check-maven.version>
   </properties>
 
   <distributionManagement>
@@ -142,7 +146,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>5.3.0</version>
+            <version>${dependency-check-maven.version}</version>
             <configuration>
               <skipProvidedScope>false</skipProvidedScope>
               <skipRuntimeScope>false</skipRuntimeScope>
@@ -150,8 +154,11 @@
                 <format>HTML</format>
                 <format>JUNIT</format>
               </formats>
-              <cveUrlBase>https://nvdcve:MoKerviNeupTaTEr@nvdcve.artifactory.syntegrity.com/nvdcve-1.0-%d.json.gz</cveUrlBase>
-              <cveUrlModified>https://nvdcve:MoKerviNeupTaTEr@nvdcve.artifactory.syntegrity.com/nvdcve-1.0-modified.json.gz</cveUrlModified>
+              <cveUrlBase>https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-%d.json.gz</cveUrlBase>
+              <cveUrlModified>https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-modified.json.gz</cveUrlModified>
+              <suppressionFiles>
+                <suppressionFile>https://raw.githubusercontent.com/cloudentity/security-gate/dev/owasp/dependency-check/project-suppression.xml</suppressionFile>
+              </suppressionFiles>
             </configuration>
             <executions>
               <execution>
@@ -171,6 +178,11 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
+        <version>${scala.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-reflect</artifactId>
         <version>${scala.version}</version>
       </dependency>
       <!-- pyron -->
@@ -277,19 +289,34 @@
         <version>${circe.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.circe</groupId>
-        <artifactId>circe-java8_2.12</artifactId>
-        <version>${circe.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>${nimbus.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>${libthrift.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.typelevel</groupId>
+        <artifactId>jawn-parser_2.12</artifactId>
+        <version>${jawn.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-parser</artifactId>
-        <version>1.0.36</version>
+        <version>${swagger-parser.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -347,7 +374,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>3.3.0</version>
+        <version>${rest-assured.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mock-server</groupId>
@@ -359,21 +386,7 @@
             <groupId>io.netty</groupId>
             <artifactId>*</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.bouncycastle</groupId><!-- 1.56 is OWASP-vulnerable -->
-            <artifactId>bcprov-jdk15on</artifactId>
-          </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>${bouncycastle.bcprov.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.pszymczyk.consul</groupId>

--- a/pyron-app/pom.xml
+++ b/pyron-app/pom.xml
@@ -136,58 +136,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <id>owasp-dependency-track</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.cyclonedx</groupId>
-            <artifactId>cyclonedx-maven-plugin</artifactId>
-            <version>2.5.1</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>makeBom</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <schemaVersion>1.1</schemaVersion>
-              <includeBomSerialNumber>true</includeBomSerialNumber>
-              <includeCompileScope>true</includeCompileScope>
-              <includeProvidedScope>true</includeProvidedScope>
-              <includeRuntimeScope>true</includeRuntimeScope>
-              <includeSystemScope>true</includeSystemScope>
-              <includeTestScope>false</includeTestScope>
-              <includeLicenseText>false</includeLicenseText>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>io.github.pmckeown</groupId>
-            <artifactId>dependency-track-maven-plugin</artifactId>
-            <version>0.8.6</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>delete-project</goal>
-                  <goal>upload-bom</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <dependencyTrackBaseUrl>${owaspdt.url}</dependencyTrackBaseUrl>
-              <apiKey>${owaspdt.api.key}</apiKey>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/pyron-core/pom.xml
+++ b/pyron-core/pom.xml
@@ -52,10 +52,6 @@
       <groupId>io.circe</groupId>
       <artifactId>circe-generic_2.12</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.circe</groupId>
-      <artifactId>circe-java8_2.12</artifactId>
-    </dependency>
     <!-- test -->
     <dependency>
       <groupId>com.cloudentity.tools.vertx</groupId>

--- a/pyron-engine/pom.xml
+++ b/pyron-engine/pom.xml
@@ -58,10 +58,6 @@
       <groupId>io.circe</groupId>
       <artifactId>circe-generic_2.12</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.circe</groupId>
-      <artifactId>circe-java8_2.12</artifactId>
-    </dependency>
     <!-- logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -119,11 +115,6 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pyron-engine/src/main/scala/com/cloudentity/pyron/rule/RulesStore.scala
+++ b/pyron-engine/src/main/scala/com/cloudentity/pyron/rule/RulesStore.scala
@@ -50,7 +50,7 @@ class RulesStoreVerticle extends ScalaServiceVerticle with RulesStore {
     RulesConfReader.read(rulesConf.toString, addresses) match {
       case \/-(rules) =>
         logRulesConf(s"Rules (${tag}) configuration", rules)
-        //log.info(s"Rules (${tag}) configuration:\n${rules.map(rule => s"   ${rule.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true))}").mkString("\n")}\n")
+        //log.info(s"Rules (${tag}) configuration:\n${rules.map(rule => s"   ${rule.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true))}").mkString("\n")}\n")
         for {
           _             <- checkPluginsReady(rules)
           extendedRules <- Future.sequence(rules.map(extendedRuleConfs)).map(_.flatten).map { extendedRules =>
@@ -72,7 +72,7 @@ class RulesStoreVerticle extends ScalaServiceVerticle with RulesStore {
       RuleConfWithPluginNames(rule.rule, requestPlugins, responsePlugins)
     }
 
-    log.info(s"$msg:\n${rs.map(rule => s"   ${rule.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true))}").mkString("\n")}\n")
+    log.info(s"$msg:\n${rs.map(rule => s"   ${rule.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true))}").mkString("\n")}\n")
   }
 
   private def checkPluginsReady(rules: List[RuleConfWithPlugins]): Future[Unit] = {
@@ -123,7 +123,7 @@ class RulesStoreVerticle extends ScalaServiceVerticle with RulesStore {
 
           s"""
              |  {
-             |    "ruleConf": ${r.asJson.pretty(printer)},
+             |    "ruleConf": ${r.asJson.printWith(printer)},
              |    "errors": ${invalidConfs.map("       " + _.asJson.noSpaces).mkString("[\n", "\n", "\n    ]")}
              |  }
              |""".stripMargin

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ApiHandlerRulesAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/ApiHandlerRulesAcceptanceTest.scala
@@ -47,7 +47,7 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
   @Test
   def shouldApplyRewritePathAndCopyQuery(ctx: TestContext): Unit = {
-    targetService.when(req().withPath("/should-apply-rewrite-path-and-copy-query-rewrite")).callback { request: HttpRequest =>
+    targetService.when(req().withPath("/should-apply-rewrite-path-and-copy-query-rewrite")).respond { request: HttpRequest =>
       if (request.hasQueryStringParameter("q", "1")) resp().withStatusCode(200)
       else resp().withStatusCode(400)
     }
@@ -60,7 +60,7 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
   }
   @Test
   def shouldApplyRewritePathAndDropQuery(ctx: TestContext): Unit = {
-    targetService.when(req().withPath("/should-apply-rewrite-path-and-drop-query-rewrite")).callback { request: HttpRequest =>
+    targetService.when(req().withPath("/should-apply-rewrite-path-and-drop-query-rewrite")).respond { request: HttpRequest =>
       if (!request.hasQueryStringParameter("q", "1")) resp().withStatusCode(200)
       else resp().withStatusCode(400)
     }
@@ -74,7 +74,7 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
   @Test
   def shouldApplyRewriteMethod(ctx: TestContext): Unit = {
-    targetService.when(req().withPath("/should-apply-rewrite-method").withMethod("POST")).callback { _ =>
+    targetService.when(req().withPath("/should-apply-rewrite-method").withMethod("POST")).respond { _: HttpRequest =>
       resp().withStatusCode(200)
     }
 
@@ -90,8 +90,8 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
     targetService.when(req()
       .withPath("/should-not-set-form-params-as-query-params-if-form-content")
       .withMethod("POST"))
-      .callback { request =>
-        if (request.getQueryStringParameters().size() == 0) resp().withStatusCode(200)
+      .respond { request: HttpRequest =>
+        if (request.getQueryStringParameterList.isEmpty) resp().withStatusCode(200)
         else resp().withStatusCode(400)
       }
 
@@ -106,7 +106,7 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
   @Test
   def shouldPreserveHostHeaderIfConfigured(ctx: TestContext): Unit = {
-    targetService.when(req().withPath("/should-preserve-host-header-if-configured")).callback { request: HttpRequest =>
+    targetService.when(req().withPath("/should-preserve-host-header-if-configured")).respond { request: HttpRequest =>
       resp().withStatusCode(200).withHeader("Request-Host", request.getFirstHeader("Host"))
     }
 
@@ -123,7 +123,7 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
   @Test
   def shouldReplaceHostHeaderByDefault(ctx: TestContext): Unit = {
-    targetService.when(req().withPath("/should-replace-host-header-by-default")).callback { request: HttpRequest =>
+    targetService.when(req().withPath("/should-replace-host-header-by-default")).respond { request: HttpRequest =>
       resp().withStatusCode(200).withHeader("Request-Host", request.getFirstHeader("Host"))
     }
 
@@ -150,7 +150,7 @@ class ApiHandlerRulesAcceptanceTest extends PyronAcceptanceTest with MockUtils {
 
   @Test
   def shouldSkipResponsePluginWhenApplyIfIsFalse(ctx: TestContext): Unit = {
-    targetService.when(req().withPath("/should-skip-plugin-when-apply-if-false")).callback { request: HttpRequest =>
+    targetService.when(req().withPath("/should-skip-plugin-when-apply-if-false")).respond { request: HttpRequest =>
       resp().withStatusCode(200)
     }
 

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TargetClientWithSmartHttpAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TargetClientWithSmartHttpAcceptanceTest.scala
@@ -135,7 +135,7 @@ class TargetClientWithSmartHttpAcceptanceTest extends PyronAcceptanceTest with M
       .when(request())
       .respond(
         response
-          .withDelay(Delay.milliseconds(200)).applyDelay()
+          .withDelay(Delay.milliseconds(200))
           .withStatusCode(200)
           .withBody(requestBody)
       )

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TransferEncodingAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/acceptance/TransferEncodingAcceptanceTest.scala
@@ -2,6 +2,7 @@ package com.cloudentity.pyron.acceptance
 
 import com.cloudentity.pyron.PyronAcceptanceTest
 import io.restassured.RestAssured.given
+import org.hamcrest.Matchers
 import org.junit.Test
 import org.scalatest.MustMatchers
 
@@ -14,6 +15,6 @@ class TransferEncodingAcceptanceTest extends PyronAcceptanceTest with MustMatche
     .when()
       .get("/chunked")
     .`then`()
-      .header("Content-Length", null.asInstanceOf[String])
+      .header("Content-Length", Matchers.nullValue())
   }
 }

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/route/ListOpenApiRouteAcceptanceTest.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/openapi/route/ListOpenApiRouteAcceptanceTest.scala
@@ -87,7 +87,7 @@ class ListOpenApiRouteAcceptanceTest extends PyronAcceptanceTest with MustMatche
   }
 
   class ListOpenApiMatcher(val expected: ListOpenApiResponse, val printer: Printer) extends BaseMatcher[ListOpenApiResponse] {
-    val expectedJson: String = expected.asJson.pretty(printer)
+    val expectedJson: String = expected.asJson.printWith(printer)
 
     override def matches(response: scala.Any): Boolean = {
       assertEquals(expectedJson, response.asInstanceOf[String])

--- a/pyron-engine/src/test/scala/com/cloudentity/pyron/util/MockUtils.scala
+++ b/pyron-engine/src/test/scala/com/cloudentity/pyron/util/MockUtils.scala
@@ -10,7 +10,7 @@ import org.mockserver.verify.VerificationTimes
 
 trait MockUtils {
   def mockOnPathWithPongingBodyAndHeaders(service: ClientAndServer)(path: String, code: Int): Unit =
-    service.when(request()).callback { request: HttpRequest =>
+    service.when(request()).respond { request: HttpRequest =>
       if (request.getPath.getValue == path)
         response()
           .withStatusCode(code)
@@ -20,10 +20,7 @@ trait MockUtils {
     }
 
   def mockOnPath(service: ClientAndServer)(path: String, resp: HttpResponse): Unit =
-    service.when(request().withPath(path)).callback { request: HttpRequest =>
-      if (request.getPath.getValue == path) resp
-      else response().withStatusCode(404)
-    }
+    service.when(request().withPath(path)).respond(resp)
 
   def mockOnPathWithBody(service: ClientAndServer)(path: String, body: String, resp: HttpResponse): Unit =
     service.when(request()
@@ -32,7 +29,7 @@ trait MockUtils {
         json(body,
           MatchType.STRICT)
       )
-    ).callback { request: HttpRequest =>
+    ).respond { request: HttpRequest =>
       if (request.getPath.getValue == path ) resp
       else response().withStatusCode(404)
     }

--- a/pyron-plugin-impl/pom.xml
+++ b/pyron-plugin-impl/pom.xml
@@ -47,11 +47,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.cloudentity.tools.vertx</groupId>
       <artifactId>vertx-test-scala</artifactId>
       <scope>test</scope>

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/methods/OAuthAuthorizationCodeIntrospectionTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/authn/methods/OAuthAuthorizationCodeIntrospectionTest.scala
@@ -45,7 +45,7 @@ class OAuthAuthorizationCodeIntrospectionTest extends PluginAcceptanceTest with 
 
   @Test
   def shouldReturnFailureIfTokenInactive(ctx: TestContext): Unit = {
-    authorizationServer.when(request()).callback { request: HttpRequest =>
+    authorizationServer.when(request()).respond { request: HttpRequest =>
       if (request.getBodyAsString().startsWith("token=user-token")) {
         response().withStatusCode(200).withBody("""{"active": false}""")
       } else response().withStatusCode(404)
@@ -61,7 +61,7 @@ class OAuthAuthorizationCodeIntrospectionTest extends PluginAcceptanceTest with 
 
   @Test
   def shouldReturnFailureIfPyronUnauthorized(ctx: TestContext): Unit = {
-    authorizationServer.when(request()).callback { request: HttpRequest =>
+    authorizationServer.when(request()).respond { request: HttpRequest =>
       if (request.getFirstHeader("Authorization").equals(authzHeader)) {
         response().withStatusCode(401)
       } else response().withStatusCode(200)
@@ -77,11 +77,11 @@ class OAuthAuthorizationCodeIntrospectionTest extends PluginAcceptanceTest with 
 
   @Test
   def shouldReturnSuccessIfTokenActive(ctx: TestContext): Unit = {
-    targetService.when(request()).callback { request: HttpRequest =>
+    targetService.when(request()).respond { request: HttpRequest =>
       response().withStatusCode(200)
     }
 
-    authorizationServer.when(request()).callback { request: HttpRequest =>
+    authorizationServer.when(request()).respond { request: HttpRequest =>
       if (request.getBodyAsString().startsWith("token=user-token") && request.getFirstHeader("Authorization").equals(authzHeader)) {
         response().withStatusCode(200).withBody("""{"active": true}""")
       } else response().withStatusCode(404)

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/bruteforce/BruteForcePluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/bruteforce/BruteForcePluginTest.scala
@@ -17,7 +17,7 @@ class BruteForcePluginTest extends PluginAcceptanceTest with MustMatchers  {
   def before(): Unit = {
     targetService = startClientAndServer(7760)
 
-    targetService.when(request()).callback { request: HttpRequest =>
+    targetService.when(request()).respond { request: HttpRequest =>
       response().withStatusCode(request.getFirstHeader("TARGET_STATUS").toInt)
     }
   }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/cors/CorsPluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/cors/CorsPluginTest.scala
@@ -25,7 +25,7 @@ class CorsPluginTest extends PluginAcceptanceTest with MustMatchers {
   @Before
   def before(): Unit = {
     targetService = startClientAndServer(7760)
-    targetService.when(request()).callback { request: HttpRequest =>
+    targetService.when(request()).respond { request: HttpRequest =>
       response().withStatusCode(200)
     }
   }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/echo/EchoPluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/echo/EchoPluginTest.scala
@@ -19,7 +19,7 @@ class EchoPluginTest extends PluginAcceptanceTest with MustMatchers {
   @Before
   def before(): Unit = {
     targetService = startClientAndServer(7760)
-    targetService.when(request()).callback { request: HttpRequest =>
+    targetService.when(request()).respond { request: HttpRequest =>
       response().withStatusCode(200)
     }
   }

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPluginAcceptanceTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/request/TransformRequestPluginAcceptanceTest.scala
@@ -16,8 +16,10 @@ class TransformRequestPluginAcceptanceTest extends PluginAcceptanceTest with Mus
   var targetService: ClientAndServer = _
 
   def getHeaderAllValues(req: HttpRequest, headerName: String): Option[List[String]] =
-    req.getHeaders.asScala.toList.find(_.getName.toString == headerName)
-      .map(v => v.getValues.asScala.toList.map(_.toString))
+    req.getHeaders.getValues(headerName).asScala.toList match {
+      case list if list.isEmpty => None
+      case list => Some(list)
+    }
 
   def getHeaderOnlyValue(req: HttpRequest, headerName: String): Option[String] = {
     getHeaderAllValues(req, headerName).map { values =>

--- a/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/response/TransformResponseCookiePluginTest.scala
+++ b/pyron-plugin-impl/src/test/scala/com/cloudentity/pyron/plugin/impl/transform/response/TransformResponseCookiePluginTest.scala
@@ -17,7 +17,7 @@ class TransformResponseCookiePluginTest extends WordSpec with MustMatchers with 
 
   def calcExpires(expireAfter: Long): String =
     ZonedDateTime.now(ZoneId.of("GMT")).plusSeconds(expireAfter)
-      .format(DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss z"))
+      .format(DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z"))
 
   "setResponseCookieDec" should {
 

--- a/sample-java-plugins/pom.xml
+++ b/sample-java-plugins/pom.xml
@@ -16,8 +16,7 @@
   <properties>
     <scala.version>2.12.9</scala.version>
     <java.version>1.8</java.version>
-    <pyron.version>1.1.0-SNAPSHOT</pyron.version>
-    <vertx-tools.version>1.7.0-SNAPSHOT</vertx-tools.version>
+    <pyron.version>${project.version}</pyron.version>
   </properties>
 
   <dependencies>

--- a/sample-scala-plugins/pom.xml
+++ b/sample-scala-plugins/pom.xml
@@ -15,8 +15,7 @@
 
   <properties>
     <scala.version>2.12.9</scala.version>
-    <pyron.version>1.1.0-SNAPSHOT</pyron.version>
-    <vertx-tools.version>1.7.0-SNAPSHOT</vertx-tools.version>
+    <pyron.version>${project.version}</pyron.version>
     <scala-maven-plugin.version>4.2.0</scala-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## [Jira task](https://cloudentity.atlassian.net/browse/SCMO-10151)

## Description

* Upgraded various dependencies to squash vulnerabilities (see CHANGELOG for details)
* Upgraded `dependency-check-maven` plugin to 6.5.3
* Removed `owasp-dependency-track` plugin (Xray is used instead)

Related PRs:

* [vertx-tools](https://github.com/cloudentity/vertx-tools/pull/69)
* [orchis-jwt](https://github.com/cloudentity/orchis-jwt/pull/5)
* [orchis-tools-vertx](https://github.com/cloudentity/orchis-tools-vertx/pull/26)
* [messaging](https://github.com/cloudentity/messaging/pull/6)
* [overlay-tools-serializers](https://github.com/cloudentity/overlay-tools-serializers/pull/7)
* [overlay-tools-base](https://github.com/cloudentity/overlay-tools-base/pull/13)
* [openapi-clients](https://github.com/cloudentity/openapi-clients/pull/11)
* [pyron](https://github.com/cloudentity/pyron/pull/113)
* [security-gate](https://github.com/cloudentity/security-gate/pull/2)
* [iam-services](https://github.com/cloudentity/iam-services/pull/240)
* [authz-service](https://github.com/cloudentity/authz-service/pull/71)
* [permission-service](https://github.com/cloudentity/permission-service/pull/41)
* [orchis-devices](https://github.com/cloudentity/orchis-devices/pull/37)
* [orchis-api-gateway](https://github.com/cloudentity/orchis-api-gateway/pull/78)
* [orchis-tes](https://github.com/cloudentity/orchis-tes/pull/30)
* [localstack](https://github.com/cloudentity/localstack/pull/495)

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [x] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)
